### PR TITLE
Improve XMPP failures.

### DIFF
--- a/xmpp/internal-xmpp.go
+++ b/xmpp/internal-xmpp.go
@@ -141,11 +141,8 @@ func (x *internalXMPP) pingPeriodically(timeout, interval time.Duration, dying <
 			if success, err := x.ping(timeout); success {
 				t.Reset(interval)
 			} else {
-				glog.Infof("XMPP ping failed; trying once more: %s", err)
-				// Ping failed; give it another try, then restart the XMPP conversation.
-				if success, _ := x.ping(timeout); !success {
-					x.Quit()
-				}
+				glog.Info(err)
+				x.Quit()
 			}
 		case interval = <-x.pingIntervalUpdates:
 			t.Reset(time.Nanosecond) // Induce ping and interval reset now.
@@ -167,8 +164,8 @@ func (x *internalXMPP) dispatchIncoming(dying chan<- struct{}) {
 			if isXMLErrorClosedConnection(err) {
 				break
 			}
-			glog.Warningf("Failed to read the next start element: %s", err)
-			continue
+			glog.Errorf("Failed to read the next start element: %s", err)
+			break
 		}
 
 		// Parse the message.


### PR DESCRIPTION
I tested this by physically disconnecting the network to my workstation,
watching XMPP fail, then reconnecting and watching it recover.

Also, the line that was repeated zillions of times will now trigger an XMPP restart, rather than an infinite retry of a failed connection.

If logs continue to pile up, then I'll jump on it straight away.