### PR TITLE
Write shims for older CUPS clients.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,10 @@ Any Linux distribution or *BSD flavor _should_ support the CUPS Connector. If yo
 
 ### Install the Connector
 ```
-$ go get github.com/google/cups-connector/connector
-$ go get github.com/google/cups-connector/connector-init
-$ go get github.com/google/cups-connector/connector-monitor
-$ go get github.com/google/cups-connector/connector-util
+$ go get github.com/google/cups-connector/...
 ```
 
-These four binary executables will be installed in $GOPATH/bin.
+Once installation completes, four binaries will be placed in $GOPATH/bin.
 
 binary              | purpose
 ------------------- | -------

--- a/cups/common.go
+++ b/cups/common.go
@@ -8,11 +8,7 @@ https://developers.google.com/open-source/licenses/bsd
 package cups
 
 /*
-#cgo LDFLAGS: -lcups
-#include <cups/cups.h>
-#include <stddef.h>      // size_t
-#include <stdlib.h>      // malloc, free
-#include <sys/utsname.h> // uname
+#include "cups.h"
 */
 import "C"
 import (

--- a/cups/core.go
+++ b/cups/core.go
@@ -8,12 +8,6 @@ https://developers.google.com/open-source/licenses/bsd
 package cups
 
 /*
-#cgo LDFLAGS: -lcups
-#include <cups/cups.h>
-#include <stddef.h>     // size_t
-#include <stdlib.h>     // free, malloc
-#include <sys/socket.h> // AF_UNSPEC
-#include <time.h>       // time_t
 #include "cups.h"
 */
 import "C"

--- a/cups/cups.h
+++ b/cups/cups.h
@@ -6,8 +6,17 @@ license that can be found in the LICENSE file or at
 https://developers.google.com/open-source/licenses/bsd
 */
 
+// Since CUPS 1.6, the ipp struct properties have been private, with accessor
+// functions added (STR #3928). This line makes the properties not private, so
+// that the connector can be compiled against pre and post 1.6 libraries.
+#define _IPP_PRIVATE_STRUCTURES 1
+
 #include <cups/cups.h>
-#include <stdlib.h> // free, calloc
+#include <stddef.h>      // size_t
+#include <stdlib.h>      // free, calloc, malloc
+#include <sys/socket.h>  // AF_UNSPEC
+#include <sys/utsname.h> // uname
+#include <time.h>        // time_t
 
 extern const char
 	*JOB_STATE,
@@ -18,9 +27,29 @@ extern const char
 	*IPP;
 
 char **newArrayOfStrings(int size);
-
 void setStringArrayValue(char **stringArray, int index, char *value);
-
 void freeStringArrayAndStrings(char **stringArray, int size);
 
-int ippGetResolutionWrapper(ipp_attribute_t *attr, int element, int *yres, int *units);
+ipp_status_t getIPPRequestStatusCode(ipp_t *ipp);
+const ipp_uchar_t *getAttributeDateValue(ipp_attribute_t *attr, int i);
+int getAttributeIntegerValue(ipp_attribute_t *attr, int i);
+const char *getAttributeStringValue(ipp_attribute_t *attr, int i);
+void getAttributeValueRange(ipp_attribute_t *attr, int i, int *lower, int *upper);
+void getAttributeValueResolution(ipp_attribute_t *attr, int i, int *xres, int *yres);
+
+#ifndef _CUPS_API_1_7
+int ippValidateAttributes(ipp_t *ipp);
+http_t *httpConnect2(const char *host, int port, http_addrlist_t *addrlist, int family,
+                     http_encryption_t encryption, int blocking, int msec, int *cancel);
+
+# define HTTP_ENCRYPTION_IF_REQUESTED HTTP_ENCRYPT_IF_REQUESTED
+# define HTTP_ENCRYPTION_NEVER        HTTP_ENCRYPT_NEVER
+# define HTTP_ENCRYPTION_REQUIRED     HTTP_ENCRYPT_REQUIRED
+# define HTTP_ENCRYPTION_ALWAYS       HTTP_ENCRYPT_ALWAYS
+# define HTTP_STATUS_OK               HTTP_OK
+# define HTTP_STATUS_NOT_MODIFIED     HTTP_NOT_MODIFIED
+# define IPP_OP_CUPS_GET_PRINTERS     CUPS_GET_PRINTERS
+# define IPP_OP_GET_JOB_ATTRIBUTES    IPP_GET_JOB_ATTRIBUTES
+# define IPP_STATUS_OK                IPP_OK
+# define IPP_STATUS_ERROR_NOT_FOUND   IPP_NOT_FOUND
+#endif

--- a/cups/ppdcache.go
+++ b/cups/ppdcache.go
@@ -8,10 +8,7 @@ https://developers.google.com/open-source/licenses/bsd
 package cups
 
 /*
-#cgo LDFLAGS: -lcups
-#include <cups/cups.h>
-#include <stdlib.h> // free
-#include <time.h>   // time_t
+#include "cups.h"
 */
 import "C"
 import (

--- a/privet/privet.go
+++ b/privet/privet.go
@@ -9,6 +9,7 @@ https://developers.google.com/open-source/licenses/bsd
 package privet
 
 import (
+	"fmt"
 	"os"
 	"sync"
 
@@ -69,7 +70,7 @@ func (p *Privet) AddPrinter(printer lib.Printer, getPrinter func() (lib.Printer,
 		online = true
 	}
 
-	# TODO once we add local-only support we should hide the append behind an if ! local-only
+	// TODO once we add local-only support we should hide the append behind an if ! local-only
 	var localDefaultDisplayName = printer.DefaultDisplayName
 	localDefaultDisplayName = fmt.Sprintf("%s (local)", localDefaultDisplayName)
 	err = p.zc.addPrinter(printer.GCPID, printer.Name, api.port(), localDefaultDisplayName, p.gcpBaseURL, printer.GCPID, online)
@@ -95,11 +96,11 @@ func (p *Privet) UpdatePrinter(diff *lib.PrinterDiff) error {
 		online = true
 	}
 
-        // TODO once we add local-only support we should hide the append behind an if ! local-only
-        var localDefaultDisplayName = diff.Printer.DefaultDisplayName
-        localDefaultDisplayName = fmt.Sprintf("%s (local)", localDefaultDisplayName)
+	// TODO once we add local-only support we should hide the append behind an if ! local-only
+	var localDefaultDisplayName = diff.Printer.DefaultDisplayName
+	localDefaultDisplayName = fmt.Sprintf("%s (local)", localDefaultDisplayName)
 
-        return p.zc.updatePrinterTXT(diff.Printer.GCPID, localDefaultDisplayName, p.gcpBaseURL, diff.Printer.GCPID, online)
+	return p.zc.updatePrinterTXT(diff.Printer.GCPID, localDefaultDisplayName, p.gcpBaseURL, diff.Printer.GCPID, online)
 }
 
 // DeletePrinter removes a printer from Privet.


### PR DESCRIPTION
Fixes #31 

I tested this by linking against older versions of CUPS (1.5.4, 1.6.4, 1.7.5), and also by compiling on an Raspberry Pi running the stock Raspbian distribution, which is essentially Debian Wheezy.