### PR TITLE
Add system-golang-version tag

### DIFF
--- a/cups/cups.go
+++ b/cups/cups.go
@@ -268,6 +268,7 @@ func getSystemTags() (map[string]string, error) {
 		tags["system-hostname"] = hostname
 	}
 	tags["system-arch"] = runtime.GOARCH
+	tags["system-golang-version"] = runtime.Version()
 
 	sysname, nodename, release, version, machine, err := uname()
 	if err != nil {


### PR DESCRIPTION
In some debugging / troubleshooting cases, it may be useful to know the version of Golang in use by the cups-connector.