### PR TITLE
Better support for commas in marker names/types

### DIFF
--- a/cups/cups.go
+++ b/cups/cups.go
@@ -523,17 +523,6 @@ func attributesToMap(attributes []*C.ipp_attribute_t) map[string][]string {
 		if len(values) == 1 && (values[0] == "none" || len(values[0]) == 0) {
 			values = []string{}
 		}
-		// This block fixes some drivers' marker types, which list an extra
-		// type containing a comma, which CUPS interprets as an extra type.
-		// The extra type starts with a space, so it's easy to detect.
-		if len(values) > 1 && len(values[len(values)-1]) > 1 && values[len(values)-1][0:1] == " " {
-			newValues := make([]string, len(values)-1)
-			for i := 0; i < len(values)-2; i++ {
-				newValues[i] = values[i]
-			}
-			newValues[len(newValues)-1] = strings.Join(values[len(values)-2:], ",")
-			values = newValues
-		}
 		m[key] = values
 	}
 

--- a/cups/translate-attrs_test.go
+++ b/cups/translate-attrs_test.go
@@ -237,21 +237,6 @@ func TestConvertMarkers(t *testing.T) {
 	}
 
 	pt = map[string][]string{
-		attrMarkerNames:  []string{"black", "color", "rainbow"},
-		attrMarkerTypes:  []string{"toner", "toner"},
-		attrMarkerLevels: []string{"10", "11", "12"},
-	}
-	m, ms = convertMarkers(pt)
-	if m != nil {
-		t.Logf("expected nil")
-		t.Fail()
-	}
-	if ms != nil {
-		t.Logf("expected nil")
-		t.Fail()
-	}
-
-	pt = map[string][]string{
 		attrMarkerNames:  []string{"black", " Reorder Part #12345", "color", "rainbow", "zebra", "pony"},
 		attrMarkerTypes:  []string{"toner", "toner", "ink", "staples", "water", " Reorder H2O"},
 		attrMarkerLevels: []string{"10", "11", "12", "208", "13"},

--- a/cups/translate-attrs_test.go
+++ b/cups/translate-attrs_test.go
@@ -207,13 +207,58 @@ func TestConvertMarkers(t *testing.T) {
 	}
 
 	pt = map[string][]string{
-		attrMarkerNames:  []string{"black", "color", "rainbow", "zebra", "pony"},
-		attrMarkerTypes:  []string{"toner", "toner", "ink", "staples", "water"},
+		attrMarkerNames:  []string{"black", "color"},
+		attrMarkerTypes:  []string{"toner", "toner", "ink"},
+		attrMarkerLevels: []string{"10", "11", "12"},
+	}
+	m, ms = convertMarkers(pt)
+	if m != nil {
+		t.Logf("expected nil")
+		t.Fail()
+	}
+	if ms != nil {
+		t.Logf("expected nil")
+		t.Fail()
+	}
+
+	pt = map[string][]string{
+		attrMarkerNames:  []string{"black", "color", "rainbow"},
+		attrMarkerTypes:  []string{"toner", "toner"},
+		attrMarkerLevels: []string{"10", "11", "12"},
+	}
+	m, ms = convertMarkers(pt)
+	if m != nil {
+		t.Logf("expected nil")
+		t.Fail()
+	}
+	if ms != nil {
+		t.Logf("expected nil")
+		t.Fail()
+	}
+
+	pt = map[string][]string{
+		attrMarkerNames:  []string{"black", "color", "rainbow"},
+		attrMarkerTypes:  []string{"toner", "toner"},
+		attrMarkerLevels: []string{"10", "11", "12"},
+	}
+	m, ms = convertMarkers(pt)
+	if m != nil {
+		t.Logf("expected nil")
+		t.Fail()
+	}
+	if ms != nil {
+		t.Logf("expected nil")
+		t.Fail()
+	}
+
+	pt = map[string][]string{
+		attrMarkerNames:  []string{"black", " Reorder Part #12345", "color", "rainbow", "zebra", "pony"},
+		attrMarkerTypes:  []string{"toner", "toner", "ink", "staples", "water", " Reorder H2O"},
 		attrMarkerLevels: []string{"10", "11", "12", "208", "13"},
 	}
 	mExpected := &[]cdd.Marker{
 		cdd.Marker{
-			VendorID: "black",
+			VendorID: "black, Reorder Part #12345",
 			Type:     cdd.MarkerToner,
 			Color:    &cdd.MarkerColor{Type: cdd.MarkerColorBlack},
 		},
@@ -237,6 +282,72 @@ func TestConvertMarkers(t *testing.T) {
 	}
 	ten, eleven, twelve, eighty := int32(10), int32(11), int32(12), int32(80)
 	msExpected := &cdd.MarkerState{
+		Item: []cdd.MarkerStateItem{
+			cdd.MarkerStateItem{
+				VendorID:     "black, Reorder Part #12345",
+				State:        cdd.MarkerStateExhausted,
+				LevelPercent: &ten,
+			},
+			cdd.MarkerStateItem{
+				VendorID:     "color",
+				State:        cdd.MarkerStateOK,
+				LevelPercent: &eleven,
+			},
+			cdd.MarkerStateItem{
+				VendorID:     "rainbow",
+				State:        cdd.MarkerStateOK,
+				LevelPercent: &twelve,
+			},
+			cdd.MarkerStateItem{
+				VendorID:     "zebra",
+				State:        cdd.MarkerStateOK,
+				LevelPercent: &eighty,
+			},
+		},
+	}
+	m, ms = convertMarkers(pt)
+	if !reflect.DeepEqual(mExpected, m) {
+		e, _ := json.Marshal(mExpected)
+		f, _ := json.Marshal(m)
+		t.Logf("expected\n %s\ngot\n %s", e, f)
+		t.Fail()
+	}
+	if !reflect.DeepEqual(msExpected, ms) {
+		e, _ := json.Marshal(msExpected)
+		f, _ := json.Marshal(ms)
+		t.Logf("expected\n %s\ngot\n %s", e, f)
+		t.Fail()
+	}
+	pt = map[string][]string{
+		attrMarkerNames:  []string{"black", "color", "rainbow", "zebra", "pony"},
+		attrMarkerTypes:  []string{"toner", "toner", "ink", "staples", "water"},
+		attrMarkerLevels: []string{"10", "11", "12", "208", "13"},
+	}
+	mExpected = &[]cdd.Marker{
+		cdd.Marker{
+			VendorID: "black",
+			Type:     cdd.MarkerToner,
+			Color:    &cdd.MarkerColor{Type: cdd.MarkerColorBlack},
+		},
+		cdd.Marker{
+			VendorID: "color",
+			Type:     cdd.MarkerToner,
+			Color:    &cdd.MarkerColor{Type: cdd.MarkerColorColor},
+		},
+		cdd.Marker{
+			VendorID: "rainbow",
+			Type:     cdd.MarkerInk,
+			Color: &cdd.MarkerColor{
+				Type: cdd.MarkerColorCustom,
+				CustomDisplayNameLocalized: cdd.NewLocalizedString("rainbow"),
+			},
+		},
+		cdd.Marker{
+			VendorID: "zebra",
+			Type:     cdd.MarkerStaples,
+		},
+	}
+	msExpected = &cdd.MarkerState{
 		Item: []cdd.MarkerStateItem{
 			cdd.MarkerStateItem{
 				VendorID:     "black",


### PR DESCRIPTION
There is already some support for weird vendor types that have a comma in them, confusing CUPS into saying there are extra types.

However the present code only checks the last element in the `[]string` which doesn't cover all cases.

(In particular, I was getting invalid Markers with Xerox Driver marker names that looked like `Drum Cartridge (R1), Reorder Number 013R00662`.)

Therefore I propose this PR that does the following things:

1. Removes the old checking code from `cups/cups.go`
2. Changes the checks for invalid markers to be:

    * Compare `len(names)` and `len(types)` to `len(levels)` instead of each other - IMO `len(levels)` is the best metric for determining mismatches because it's the one we can be most sure about the printer not sending weird values.
    * Only try to fix names and types when there is a length mismatch; no need in trying to fix something already good, or even possibly messing something up that would work
    * Check over the whole range of names and types instead of the last element

3. Adds tests for the new code

Let me know if there is anything else I need to do to get this accepted/merged.

Thanks!