### PR TITLE
add delete/cancel job(s) arguments to connector-util

### DIFF
--- a/connector-util/connector-util.go
+++ b/connector-util/connector-util.go
@@ -83,16 +83,16 @@ func main() {
 }
 
 // getConfig returns a config object
-func getConfig() lib.Config {
+func getConfig() *lib.Config {
 	config, err := lib.ConfigFromFile()
 	if err != nil {
 		panic(err)
 	}
-	return *config
+	return config
 }
 
 // getGCP returns a GoogleCloudPrint object
-func getGCP(config lib.Config) gcp.GoogleCloudPrint {
+func getGCP(config *lib.Config) *gcp.GoogleCloudPrint {
 	gcp, err := gcp.NewGoogleCloudPrint(config.GCPBaseURL, config.RobotRefreshToken,
 		config.UserRefreshToken, config.ProxyName, config.GCPOAuthClientID,
 		config.GCPOAuthClientSecret, config.GCPOAuthAuthURL, config.GCPOAuthTokenURL,
@@ -100,7 +100,7 @@ func getGCP(config lib.Config) gcp.GoogleCloudPrint {
 	if err != nil {
 		panic(err)
 	}
-	return *gcp
+	return gcp
 }
 
 // updateConfigFile opens the config file, adds any missing fields,

--- a/connector-util/connector-util.go
+++ b/connector-util/connector-util.go
@@ -12,7 +12,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"time"
 
 	"github.com/google/cups-connector/cdd"
 	"github.com/google/cups-connector/gcp"
@@ -257,15 +256,10 @@ func deleteAllGCPPrinters() {
 		panic(err)
 	}
 
-	gcpXMPPPingIntervalDefault, err := time.ParseDuration(config.XMPPPingIntervalDefault)
-	if err != nil {
-		glog.Fatalf("Failed to parse xmpp ping interval default: %s", err)
-	}
-
 	gcp, err := gcp.NewGoogleCloudPrint(config.GCPBaseURL, config.RobotRefreshToken,
 		config.UserRefreshToken, config.ProxyName, config.GCPOAuthClientID,
 		config.GCPOAuthClientSecret, config.GCPOAuthAuthURL, config.GCPOAuthTokenURL,
-		gcpXMPPPingIntervalDefault, 0, nil)
+		0, nil)
 	if err != nil {
 		glog.Fatal(err)
 	}
@@ -300,15 +294,10 @@ func deleteGCPJob() {
 		panic(err)
 	}
 
-	gcpXMPPPingIntervalDefault, err := time.ParseDuration(config.XMPPPingIntervalDefault)
-	if err != nil {
-		glog.Fatalf("Failed to parse xmpp ping interval default: %s", err)
-	}
-
 	gcp, err := gcp.NewGoogleCloudPrint(config.GCPBaseURL, config.RobotRefreshToken,
 		config.UserRefreshToken, config.ProxyName, config.GCPOAuthClientID,
 		config.GCPOAuthClientSecret, config.GCPOAuthAuthURL, config.GCPOAuthTokenURL,
-		gcpXMPPPingIntervalDefault, 0, nil)
+		0, nil)
 	if err != nil {
 		glog.Fatal(err)
 	}
@@ -328,15 +317,10 @@ func cancelGCPJob() {
 		panic(err)
 	}
 
-	gcpXMPPPingIntervalDefault, err := time.ParseDuration(config.XMPPPingIntervalDefault)
-	if err != nil {
-		glog.Fatalf("Failed to parse xmpp ping interval default: %s", err)
-	}
-
 	gcp, err := gcp.NewGoogleCloudPrint(config.GCPBaseURL, config.RobotRefreshToken,
 		config.UserRefreshToken, config.ProxyName, config.GCPOAuthClientID,
 		config.GCPOAuthClientSecret, config.GCPOAuthAuthURL, config.GCPOAuthTokenURL,
-		gcpXMPPPingIntervalDefault, 0, nil)
+		0, nil)
 	if err != nil {
 		glog.Fatal(err)
 	}
@@ -364,15 +348,10 @@ func deleteAllGCPPrinterJobs() {
 		panic(err)
 	}
 
-	gcpXMPPPingIntervalDefault, err := time.ParseDuration(config.XMPPPingIntervalDefault)
-	if err != nil {
-		glog.Fatalf("Failed to parse xmpp ping interval default: %s", err)
-	}
-
 	gcp, err := gcp.NewGoogleCloudPrint(config.GCPBaseURL, config.RobotRefreshToken,
 		config.UserRefreshToken, config.ProxyName, config.GCPOAuthClientID,
 		config.GCPOAuthClientSecret, config.GCPOAuthAuthURL, config.GCPOAuthTokenURL,
-		gcpXMPPPingIntervalDefault, 0, nil)
+		0, nil)
 	if err != nil {
 		glog.Fatal(err)
 	}
@@ -403,15 +382,10 @@ func cancelAllGCPPrinterJobs() {
 		panic(err)
 	}
 
-	gcpXMPPPingIntervalDefault, err := time.ParseDuration(config.XMPPPingIntervalDefault)
-	if err != nil {
-		glog.Fatalf("Failed to parse xmpp ping interval default: %s", err)
-	}
-
 	gcp, err := gcp.NewGoogleCloudPrint(config.GCPBaseURL, config.RobotRefreshToken,
 		config.UserRefreshToken, config.ProxyName, config.GCPOAuthClientID,
 		config.GCPOAuthClientSecret, config.GCPOAuthAuthURL, config.GCPOAuthTokenURL,
-		gcpXMPPPingIntervalDefault, 0, nil)
+		0, nil)
 	if err != nil {
 		glog.Fatal(err)
 	}
@@ -449,15 +423,10 @@ func showGCPPrinterStatus() {
 		panic(err)
 	}
 
-	gcpXMPPPingIntervalDefault, err := time.ParseDuration(config.XMPPPingIntervalDefault)
-	if err != nil {
-		glog.Fatalf("Failed to parse xmpp ping interval default: %s", err)
-	}
-
 	gcp, err := gcp.NewGoogleCloudPrint(config.GCPBaseURL, config.RobotRefreshToken,
 		config.UserRefreshToken, config.ProxyName, config.GCPOAuthClientID,
 		config.GCPOAuthClientSecret, config.GCPOAuthAuthURL, config.GCPOAuthTokenURL,
-		gcpXMPPPingIntervalDefault, 0, nil)
+		0, nil)
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -81,7 +81,7 @@ func main() {
 		g, err = gcp.NewGoogleCloudPrint(config.GCPBaseURL, config.RobotRefreshToken,
 			config.UserRefreshToken, config.ProxyName, config.GCPOAuthClientID,
 			config.GCPOAuthClientSecret, config.GCPOAuthAuthURL, config.GCPOAuthTokenURL,
-			gcpXMPPPingIntervalDefault, config.GCPMaxConcurrentDownloads, jobs)
+			config.GCPMaxConcurrentDownloads, jobs)
 		if err != nil {
 			glog.Fatal(err)
 		}

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -71,10 +71,10 @@ func NewGoogleCloudPrint(baseURL, robotRefreshToken, userRefreshToken, proxyName
 	}
 
 	gcp := &GoogleCloudPrint{
-		baseURL:                 baseURL,
-		robotClient:             robotClient,
-		userClient:              userClient,
-		proxyName:               proxyName,
+		baseURL:           baseURL,
+		robotClient:       robotClient,
+		userClient:        userClient,
+		proxyName:         proxyName,
 		jobs:              jobs,
 		downloadSemaphore: lib.NewSemaphore(maxConcurrentDownload),
 	}
@@ -127,7 +127,7 @@ func (gcp *GoogleCloudPrint) Delete(gcpID string) error {
 }
 
 // DeleteJob calls google.com/cloudprint/deletejob to delete a print job.
-func (gcp *GoogleCloudPrint) DeleteJob(gcpJobID string) (error) {
+func (gcp *GoogleCloudPrint) DeleteJob(gcpJobID string) error {
 	form := url.Values{}
 	form.Set("jobid", gcpJobID)
 
@@ -137,6 +137,7 @@ func (gcp *GoogleCloudPrint) DeleteJob(gcpJobID string) (error) {
 
 	return nil
 }
+
 // Fetch calls google.com/cloudprint/fetch to get the outstanding print jobs for
 // a GCP printer.
 func (gcp *GoogleCloudPrint) Fetch(gcpID string) ([]Job, error) {
@@ -179,7 +180,6 @@ func (gcp *GoogleCloudPrint) Fetch(gcpID string) ([]Job, error) {
 	return jobs, nil
 }
 
-
 // Jobs calls google.com/cloudprint/jobs to get print jobs for a GCP printer.
 func (gcp *GoogleCloudPrint) Jobs(gcpID string) ([]Job, error) {
 	form := url.Values{}
@@ -192,9 +192,9 @@ func (gcp *GoogleCloudPrint) Jobs(gcpID string) ([]Job, error) {
 
 	var jobsData struct {
 		Jobs []struct {
-			ID      string
-			Title   string
-			OwnerID string
+			ID            string
+			Title         string
+			OwnerID       string
 			SemanticState *cdd.PrintJobState
 		}
 	}

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -56,7 +56,7 @@ type GoogleCloudPrint struct {
 }
 
 // NewGoogleCloudPrint establishes a connection with GCP, returns a new GoogleCloudPrint object.
-func NewGoogleCloudPrint(baseURL, robotRefreshToken, userRefreshToken, proxyName, oauthClientID, oauthClientSecret, oauthAuthURL, oauthTokenURL string, xmppPingIntervalDefault time.Duration, maxConcurrentDownload uint, jobs chan<- *lib.Job) (*GoogleCloudPrint, error) {
+func NewGoogleCloudPrint(baseURL, robotRefreshToken, userRefreshToken, proxyName, oauthClientID, oauthClientSecret, oauthAuthURL, oauthTokenURL string, maxConcurrentDownload uint, jobs chan<- *lib.Job) (*GoogleCloudPrint, error) {
 	robotClient, err := newClient(oauthClientID, oauthClientSecret, oauthAuthURL, oauthTokenURL, robotRefreshToken, ScopeCloudPrint, ScopeGoogleTalk)
 	if err != nil {
 		return nil, err
@@ -75,7 +75,6 @@ func NewGoogleCloudPrint(baseURL, robotRefreshToken, userRefreshToken, proxyName
 		robotClient:             robotClient,
 		userClient:              userClient,
 		proxyName:               proxyName,
-		xmppPingIntervalDefault: xmppPingIntervalDefault,
 		jobs:              jobs,
 		downloadSemaphore: lib.NewSemaphore(maxConcurrentDownload),
 	}

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -127,7 +127,7 @@ func (gcp *GoogleCloudPrint) Delete(gcpID string) error {
 	return nil
 }
 
-// DeleteJob deletes a print job
+// DeleteJob calls google.com/cloudprint/deletejob to delete a print job.
 func (gcp *GoogleCloudPrint) DeleteJob(gcpJobID string) (error) {
 	form := url.Values{}
 	form.Set("jobid", gcpJobID)

--- a/gcp/job.go
+++ b/gcp/job.go
@@ -7,10 +7,13 @@ https://developers.google.com/open-source/licenses/bsd
 */
 package gcp
 
+import "github.com/google/cups-connector/cdd"
+
 type Job struct {
-	GCPPrinterID string
-	GCPJobID     string
-	FileURL      string
-	OwnerID      string
-	Title        string
+	GCPPrinterID  string
+	GCPJobID      string
+	FileURL       string
+	OwnerID       string
+	Title         string
+	SemanticState *cdd.PrintJobState
 }


### PR DESCRIPTION
Adds arguments to connector-util:
```
  -cancel-all-gcp-printer-jobs
        Cancels all queued jobs associated with a printer
  -cancel-gcp-job string
        Cancels one GCP job
  -delete-all-gcp-printer-jobs
        Delete all queued jobs associated with a printer
  -delete-all-gcp-printers
        Delete all printers associated with this connector
  -delete-gcp-job string
        Deletes one GCP job
  -printer-id string
        Specifies ID of printer to use
  -show-gcp-printer-status
        Shows the current status of a printer and it's jobs
```