### PR TITLE
use presence of robot token to determine if cloud printing should be enabled

### DIFF
--- a/connector-util/connector-util.go
+++ b/connector-util/connector-util.go
@@ -253,8 +253,13 @@ func updateConfigFile() {
 	}
 	if _, exists := configMap["cloud_printing_enable"]; !exists {
 		dirty = true
+		_, robot_token_exists := configMap["robot_refresh_token"]
 		fmt.Println("Added cloud_printing_enable")
-		config.CloudPrintingEnable = lib.DefaultConfig.CloudPrintingEnable
+		if robot_token_exists {
+			config.CloudPrintingEnable = true
+		} else {
+			config.CloudPrintingEnable = lib.DefaultConfig.CloudPrintingEnable
+		}
 	}
 
 	if dirty {


### PR DESCRIPTION
Today connector-util always sets cloud_printing_enabled to false when upgrading an existing config file. This doesn't seem like the right decision for connectors that have already been configured pre-local printing.

This patch will instead look for the presence of robot_refresh_token to determine if cloud_printing_enabled should be true.