### PR TITLE
CUPS < 1.5 doesn't send printer-uuid attribute.

### DIFF
--- a/cups/translate-attrs.go
+++ b/cups/translate-attrs.go
@@ -59,6 +59,9 @@ func getUUID(printerTags map[string][]string) string {
 		uuid = u[0]
 		uuid = strings.TrimPrefix(uuid, "urn:")
 		uuid = strings.TrimPrefix(uuid, "uuid:")
+	} else if u, ok := printerTags[attrPrinterName]; ok {
+		// CUPS < 1.5 doesn't send a printer-uuid attribute.
+		uuid = u[0]
 	}
 	return uuid
 }

--- a/cups/translate-attrs_test.go
+++ b/cups/translate-attrs_test.go
@@ -67,6 +67,26 @@ func TestGetUUID(t *testing.T) {
 		t.Logf("expected %s, got %s", expected, u)
 		t.Fail()
 	}
+
+	pt = map[string][]string{
+		attrPrinterUUID: []string{"urn:uuid:123"},
+		attrPrinterName: []string{"my-name"},
+	}
+	u = getUUID(pt)
+	if u != expected {
+		t.Logf("expected %s, got %s", expected, u)
+		t.Fail()
+	}
+
+	pt = map[string][]string{
+		attrPrinterName: []string{"my-name"},
+	}
+	expected = "my-name"
+	u = getUUID(pt)
+	if u != expected {
+		t.Logf("expected %s, got %s", expected, u)
+		t.Fail()
+	}
 }
 
 func TestGetState(t *testing.T) {


### PR DESCRIPTION
Fixes #101