### PR TITLE
Make GCP job id prefix to job title optional.

### DIFF
--- a/gcp-cups-connector-util/gcp-cups-connector-util.go
+++ b/gcp-cups-connector-util/gcp-cups-connector-util.go
@@ -121,6 +121,10 @@ func updateConfigFile() {
 	if err != nil {
 		panic(err)
 	}
+	if configFilename == "" {
+		fmt.Println("Could not find a config file to update")
+		return
+	}
 
 	// Same config in []byte format.
 	configRaw, err := ioutil.ReadFile(configFilename)

--- a/gcp-cups-connector-util/init.go
+++ b/gcp-cups-connector-util/init.go
@@ -63,6 +63,9 @@ var (
 	copyPrinterInfoToDisplayNameFlag = flag.String(
 		"copy-printer-info-to-display-name", "",
 		"Whether to copy the CUPS printer's printer-info attribute to the GCP printer's defaultDisplayName")
+	prefixJobIDToJobTitleFlag = flag.String(
+		"prefix-job-id-to-job-title", "",
+		"Whether to add the job ID to the beginning of the job title")
 	displayNamePrefixFlag = flag.String(
 		"display-name-prefix", "",
 		"Prefix to add to GCP printer's defaultDisplayName")
@@ -390,6 +393,7 @@ func createConfigFile(xmppJID, robotRefreshToken, userRefreshToken, shareScope, 
 		flagToBool(cupsJobFullUsernameFlag, lib.DefaultConfig.CUPSJobFullUsername),
 		flagToBool(cupsIgnoreRawPrintersFlag, lib.DefaultConfig.CUPSIgnoreRawPrinters),
 		flagToBool(copyPrinterInfoToDisplayNameFlag, lib.DefaultConfig.CopyPrinterInfoToDisplayName),
+		flagToBool(prefixJobIDToJobTitleFlag, lib.DefaultConfig.PrefixJobIDToJobTitle),
 		flagToString(displayNamePrefixFlag, lib.DefaultConfig.DisplayNamePrefix),
 		flagToString(monitorSocketFilenameFlag, lib.DefaultConfig.MonitorSocketFilename),
 		flagToString(gcpBaseURLFlag, lib.DefaultConfig.GCPBaseURL),

--- a/gcp-cups-connector/gcp-cups-connector.go
+++ b/gcp-cups-connector/gcp-cups-connector.go
@@ -91,8 +91,9 @@ func main() {
 		defer x.Quit()
 	}
 
-	c, err := cups.NewCUPS(config.CopyPrinterInfoToDisplayName, config.DisplayNamePrefix,
-		config.CUPSPrinterAttributes, config.CUPSMaxConnections, cupsConnectTimeout)
+	c, err := cups.NewCUPS(config.CopyPrinterInfoToDisplayName, config.PrefixJobIDToJobTitle,
+		config.DisplayNamePrefix, config.CUPSPrinterAttributes, config.CUPSMaxConnections,
+		cupsConnectTimeout)
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -630,12 +630,10 @@ func (gcp *GoogleCloudPrint) processJob(job *Job, printer *lib.Printer, reportJo
 		return
 	}
 
-	jobTitle := fmt.Sprintf("gcp:%s %s", job.GCPJobID, job.Title)
-
 	gcp.jobs <- &lib.Job{
 		CUPSPrinterName: printer.Name,
 		Filename:        filename,
-		Title:           jobTitle,
+		Title:           job.Title,
 		User:            job.OwnerID,
 		JobID:           job.GCPJobID,
 		Ticket:          ticket,

--- a/lib/config.go
+++ b/lib/config.go
@@ -85,6 +85,9 @@ type Config struct {
 	// Whether to copy the CUPS printer's printer-info attribute to the GCP printer's defaultDisplayName.
 	CopyPrinterInfoToDisplayName bool `json:"copy_printer_info_to_display_name"`
 
+	// Whether to add the job ID to the beginning of the job title. Useful for debugging.
+	PrefixJobIDToJobTitle bool `json:"prefix_job_id_to_job_title"`
+
 	// Prefix for all GCP printers hosted by this connector.
 	DisplayNamePrefix string `json:"display_name_prefix"`
 
@@ -172,6 +175,7 @@ var DefaultConfig = Config{
 	CUPSJobFullUsername:          false,
 	CUPSIgnoreRawPrinters:        true,
 	CopyPrinterInfoToDisplayName: true,
+	PrefixJobIDToJobTitle:        false,
 	DisplayNamePrefix:            "",
 	MonitorSocketFilename:        "/tmp/cups-connector-monitor.sock",
 	GCPBaseURL:                   "https://www.google.com/cloudprint/",

--- a/manager/printermanager.go
+++ b/manager/printermanager.go
@@ -395,7 +395,7 @@ func (pm *PrinterManager) printJob(cupsPrinterName, filename, title, user, jobID
 	printer.CUPSJobSemaphore.Acquire()
 	defer printer.CUPSJobSemaphore.Release()
 
-	cupsJobID, err := pm.cups.Print(printer.Name, filename, title, user, ticket)
+	cupsJobID, err := pm.cups.Print(printer.Name, filename, title, user, jobID, ticket)
 	if err != nil {
 		pm.incrementJobsProcessed(false)
 		glog.Errorf("Failed to send job %s to CUPS: %s", jobID, err)


### PR DESCRIPTION
And off by default. Fixes #103