### PR TITLE
Don't mention non-functional domain sharing

### DIFF
--- a/gcp-cups-connector-util/init.go
+++ b/gcp-cups-connector-util/init.go
@@ -500,7 +500,7 @@ func initConfigFile() {
 			if len(*shareScopeFlag) > 0 {
 				shareScope = *shareScopeFlag
 			} else {
-				shareScope = scanNonEmptyString("User or group email address, or domain name, to share with:")
+				shareScope = scanNonEmptyString("User or group email address to share with:")
 			}
 		} else {
 			fmt.Println(


### PR DESCRIPTION
Sharing a printer with a domain doesn't actually work. The /share call can be made but there's no way to approve the sharing domain-wide (apparently it was never implemented). Remove mention of domain sharing.