### PR TITLE
Pass printer, instead of printername, to cups.Print().

### DIFF
--- a/cdd/cdd.go
+++ b/cdd/cdd.go
@@ -316,7 +316,8 @@ type TypedValueCapability struct {
 }
 
 type Color struct {
-	Option []ColorOption `json:"option"`
+	Option    []ColorOption `json:"option"`
+	VendorKey string        `json:"-"`
 }
 
 type ColorType string
@@ -338,7 +339,8 @@ type ColorOption struct {
 }
 
 type Duplex struct {
-	Option []DuplexOption `json:"option"`
+	Option    []DuplexOption `json:"option"`
+	VendorKey string         `json:"-"`
 }
 
 type DuplexType string
@@ -352,6 +354,7 @@ const (
 type DuplexOption struct {
 	Type      DuplexType `json:"type"`       // default = "NO_DUPLEX"
 	IsDefault bool       `json:"is_default"` // default = false
+	VendorID  string     `json:"-"`
 }
 
 type PageOrientation struct {

--- a/cups/translate-ppd.go
+++ b/cups/translate-ppd.go
@@ -539,7 +539,6 @@ func convertColorPPD(e entry) *cdd.Color {
 }
 
 func convertDuplex(e entry) *cdd.Duplex {
-	// TODO: Test on a real Konica Minolta printer.
 	d := cdd.Duplex{VendorKey: e.mainKeyword}
 
 	var foundDefault bool

--- a/cups/translate-ppd_test.go
+++ b/cups/translate-ppd_test.go
@@ -75,9 +75,10 @@ func TestTrColor(t *testing.T) {
 	expected := &cdd.PrinterDescriptionSection{
 		Color: &cdd.Color{
 			Option: []cdd.ColorOption{
-				cdd.ColorOption{"ColorModel:CMYK", cdd.ColorTypeStandardColor, "", false, cdd.NewLocalizedString("Color")},
-				cdd.ColorOption{"ColorModel:Gray", cdd.ColorTypeStandardMonochrome, "", true, cdd.NewLocalizedString("Black and White")},
+				cdd.ColorOption{"CMYK", cdd.ColorTypeStandardColor, "", false, cdd.NewLocalizedString("Color")},
+				cdd.ColorOption{"Gray", cdd.ColorTypeStandardMonochrome, "", true, cdd.NewLocalizedString("Black and White")},
 			},
+			VendorKey: "ColorModel",
 		},
 	}
 	translationTest(t, ppd, expected)
@@ -97,9 +98,10 @@ func TestTrColor(t *testing.T) {
 	expected = &cdd.PrinterDescriptionSection{
 		Color: &cdd.Color{
 			Option: []cdd.ColorOption{
-				cdd.ColorOption{"CMAndResolution:CMYKImageRET3600", cdd.ColorTypeStandardColor, "", true, cdd.NewLocalizedString("Color")},
-				cdd.ColorOption{"CMAndResolution:Gray600x600dpi", cdd.ColorTypeStandardMonochrome, "", false, cdd.NewLocalizedString("Gray")},
+				cdd.ColorOption{"CMYKImageRET3600", cdd.ColorTypeStandardColor, "", true, cdd.NewLocalizedString("Color")},
+				cdd.ColorOption{"Gray600x600dpi", cdd.ColorTypeStandardMonochrome, "", false, cdd.NewLocalizedString("Gray")},
 			},
+			VendorKey: "CMAndResolution",
 		},
 	}
 	translationTest(t, ppd, expected)
@@ -116,10 +118,11 @@ func TestTrColor(t *testing.T) {
 	expected = &cdd.PrinterDescriptionSection{
 		Color: &cdd.Color{
 			Option: []cdd.ColorOption{
-				cdd.ColorOption{"CMAndResolution:CMYKImageRET2400", cdd.ColorTypeStandardColor, "", true, cdd.NewLocalizedString("Color, ImageRET 2400")},
-				cdd.ColorOption{"CMAndResolution:Gray1200x1200dpi", cdd.ColorTypeCustomMonochrome, "", false, cdd.NewLocalizedString("Gray, ProRes 1200")},
-				cdd.ColorOption{"CMAndResolution:Gray600x600dpi", cdd.ColorTypeCustomMonochrome, "", false, cdd.NewLocalizedString("Gray, 600 dpi")},
+				cdd.ColorOption{"CMYKImageRET2400", cdd.ColorTypeStandardColor, "", true, cdd.NewLocalizedString("Color, ImageRET 2400")},
+				cdd.ColorOption{"Gray1200x1200dpi", cdd.ColorTypeCustomMonochrome, "", false, cdd.NewLocalizedString("Gray, ProRes 1200")},
+				cdd.ColorOption{"Gray600x600dpi", cdd.ColorTypeCustomMonochrome, "", false, cdd.NewLocalizedString("Gray, 600 dpi")},
 			},
+			VendorKey: "CMAndResolution",
 		},
 	}
 	translationTest(t, ppd, expected)
@@ -135,9 +138,10 @@ func TestTrColor(t *testing.T) {
 	expected = &cdd.PrinterDescriptionSection{
 		Color: &cdd.Color{
 			Option: []cdd.ColorOption{
-				cdd.ColorOption{"SelectColor:Color", cdd.ColorTypeStandardColor, "", true, cdd.NewLocalizedString("Color")},
-				cdd.ColorOption{"SelectColor:Grayscale", cdd.ColorTypeStandardMonochrome, "", false, cdd.NewLocalizedString("Grayscale")},
+				cdd.ColorOption{"Color", cdd.ColorTypeStandardColor, "", true, cdd.NewLocalizedString("Color")},
+				cdd.ColorOption{"Grayscale", cdd.ColorTypeStandardMonochrome, "", false, cdd.NewLocalizedString("Grayscale")},
 			},
+			VendorKey: "SelectColor",
 		},
 	}
 	translationTest(t, ppd, expected)
@@ -153,9 +157,10 @@ func TestTrDuplex(t *testing.T) {
 	expected := &cdd.PrinterDescriptionSection{
 		Duplex: &cdd.Duplex{
 			Option: []cdd.DuplexOption{
-				cdd.DuplexOption{cdd.DuplexNoDuplex, true},
-				cdd.DuplexOption{cdd.DuplexLongEdge, false},
+				cdd.DuplexOption{cdd.DuplexNoDuplex, true, "None"},
+				cdd.DuplexOption{cdd.DuplexLongEdge, false, "DuplexNoTumble"},
 			},
+			VendorKey: "Duplex",
 		},
 	}
 	translationTest(t, ppd, expected)
@@ -180,9 +185,11 @@ func TestTrKMDuplex(t *testing.T) {
 	expected := &cdd.PrinterDescriptionSection{
 		Duplex: &cdd.Duplex{
 			Option: []cdd.DuplexOption{
-				cdd.DuplexOption{cdd.DuplexNoDuplex, false},
-				cdd.DuplexOption{cdd.DuplexLongEdge, true},
+				cdd.DuplexOption{cdd.DuplexNoDuplex, false, "Single"},
+				cdd.DuplexOption{cdd.DuplexLongEdge, true, "Double"},
+				cdd.DuplexOption{cdd.DuplexShortEdge, false, "Booklet"},
 			},
+			VendorKey: "KMDuplex",
 		},
 	}
 	translationTest(t, ppd, expected)
@@ -198,9 +205,10 @@ func TestTrKMDuplex(t *testing.T) {
 	expected = &cdd.PrinterDescriptionSection{
 		Duplex: &cdd.Duplex{
 			Option: []cdd.DuplexOption{
-				cdd.DuplexOption{cdd.DuplexNoDuplex, true},
-				cdd.DuplexOption{cdd.DuplexLongEdge, false},
+				cdd.DuplexOption{cdd.DuplexNoDuplex, true, "False"},
+				cdd.DuplexOption{cdd.DuplexLongEdge, false, "True"},
 			},
+			VendorKey: "KMDuplex",
 		},
 	}
 	translationTest(t, ppd, expected)

--- a/manager/printermanager.go
+++ b/manager/printermanager.go
@@ -389,10 +389,7 @@ func (pm *PrinterManager) printJob(cupsPrinterName, filename, title, user, jobID
 		return
 	}
 
-	printer.CUPSJobSemaphore.Acquire()
-	defer printer.CUPSJobSemaphore.Release()
-
-	cupsJobID, err := pm.cups.Print(printer.Name, filename, title, user, jobID, ticket)
+	cupsJobID, err := pm.cups.Print(&printer, filename, title, user, jobID, ticket)
 	if err != nil {
 		pm.incrementJobsProcessed(false)
 		log.ErrorJobf(jobID, "Failed to submit to CUPS: %s", err)


### PR DESCRIPTION
Ticket parsing is more accurate because the lib.Printer object is
available for reference and to verify ticket parameters. This is
particularly useful for duplexing, as the CDD Duplex.Option struct
doesn't include a VendorID field.

Fixes #88