### PR TITLE
Fix unnecessary GCP update on start.

### DIFF
--- a/lib/printer.go
+++ b/lib/printer.go
@@ -9,6 +9,8 @@ https://developers.google.com/open-source/licenses/bsd
 package lib
 
 import (
+	"bytes"
+	"encoding/json"
 	"reflect"
 	"regexp"
 
@@ -185,7 +187,11 @@ func diffPrinter(pc, pg *Printer) PrinterDiff {
 	if !reflect.DeepEqual(pg.State, pc.State) {
 		d.StateChanged = true
 	}
-	if !reflect.DeepEqual(pg.Description, pc.Description) {
+	// PrinterDescriptionSection objects contain fields that are not exported to JSON,
+	// and therefore cause comparison with GCP's copy to incorrectly appear not equal.
+	pgDescJSON, _ := json.Marshal(pg.Description)
+	pcDescJSON, _ := json.Marshal(pc.Description)
+	if !bytes.Equal(pgDescJSON, pcDescJSON) {
 		d.DescriptionChanged = true
 	}
 	if pg.CapsHash != pc.CapsHash {


### PR DESCRIPTION
Introduction of fields not exported to JSON causes comparison between
local and GCP copies to return "not equal". In fact, they are equal.