### PR TITLE
Unshare function and extend Share parameters

### DIFF
--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"strconv"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -469,7 +470,7 @@ func marshalCapabilities(description *cdd.PrinterDescriptionSection) (string, er
 }
 
 // Share calls google.com/cloudprint/share to share a registered GCP printer.
-func (gcp *GoogleCloudPrint) Share(gcpID, shareScope string) error {
+func (gcp *GoogleCloudPrint) Share(gcpID, shareScope string, role string, skip_notification bool) error {
 	if gcp.userClient == nil {
 		return errors.New("Cannot share because user OAuth credentials not provided.")
 	}
@@ -477,14 +478,31 @@ func (gcp *GoogleCloudPrint) Share(gcpID, shareScope string) error {
 	form := url.Values{}
 	form.Set("printerid", gcpID)
 	form.Set("scope", shareScope)
-	form.Set("role", "USER")
-	form.Set("skip_notification", "true")
+	form.Set("role", role)
+	form.Set("skip_notification", strconv.FormatBool(skip_notification))
 
 	if _, _, _, err := postWithRetry(gcp.userClient, gcp.baseURL+"share", form); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// Unshare calls google.com/cloudprint/unshare to unshare a registered GCP printer.
+func (gcp *GoogleCloudPrint) Unshare(gcpID, shareScope string) error {
+	if  gcp.userClient == nil {
+                return errors.New("Cannot share because user OAuth credentials not provided.")
+        }
+
+        form := url.Values{}
+	form.Set("printerid", gcpID)
+	form.Set("scope", "scope")
+
+	if _, _, _, err := postWithRetry(gcp.userClient, gcp.baseURL+"unshare", form); err != nil {
+                return err
+        }
+
+        return nil
 }
 
 // Download downloads a URL (a print job data file) directly to a Writer.

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -55,15 +55,6 @@ type GoogleCloudPrint struct {
 	downloadSemaphore *lib.Semaphore
 }
 
-// Role is the role a user or group is granted when sharing a printer.
-type Role string
-
-const (
-	User    Role = "USER"
-	Manager Role = "MANAGER"
-	Owner   Role = "OWNER"
-)
-
 // NewGoogleCloudPrint establishes a connection with GCP, returns a new GoogleCloudPrint object.
 func NewGoogleCloudPrint(baseURL, robotRefreshToken, userRefreshToken, proxyName, oauthClientID, oauthClientSecret, oauthAuthURL, oauthTokenURL string, maxConcurrentDownload uint, jobs chan<- *lib.Job) (*GoogleCloudPrint, error) {
 	robotClient, err := newClient(oauthClientID, oauthClientSecret, oauthAuthURL, oauthTokenURL, robotRefreshToken, ScopeCloudPrint, ScopeGoogleTalk)
@@ -477,6 +468,15 @@ func marshalCapabilities(description *cdd.PrinterDescriptionSection) (string, er
 
 	return string(cdd), nil
 }
+
+// Role is the role a user or group is granted when sharing a printer.
+type Role string
+
+const (
+	User    Role = "USER"
+	Manager Role = "MANAGER"
+	Owner   Role = "OWNER"
+)
 
 // Share calls google.com/cloudprint/share to share a registered GCP printer.
 func (gcp *GoogleCloudPrint) Share(gcpID, shareScope string, role Role, skip_notification bool) error {

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -20,8 +20,8 @@ import (
 	"net/url"
 	"os"
 	"sort"
-	"strings"
 	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -490,19 +490,19 @@ func (gcp *GoogleCloudPrint) Share(gcpID, shareScope string, role string, skip_n
 
 // Unshare calls google.com/cloudprint/unshare to unshare a registered GCP printer.
 func (gcp *GoogleCloudPrint) Unshare(gcpID, shareScope string) error {
-	if  gcp.userClient == nil {
-                return errors.New("Cannot share because user OAuth credentials not provided.")
-        }
+	if gcp.userClient == nil {
+		return errors.New("Cannot unshare because user OAuth credentials not provided.")
+	}
 
-        form := url.Values{}
+	form := url.Values{}
 	form.Set("printerid", gcpID)
 	form.Set("scope", "scope")
 
 	if _, _, _, err := postWithRetry(gcp.userClient, gcp.baseURL+"unshare", form); err != nil {
-                return err
-        }
+		return err
+	}
 
-        return nil
+	return nil
 }
 
 // Download downloads a URL (a print job data file) directly to a Writer.

--- a/manager/printermanager.go
+++ b/manager/printermanager.go
@@ -225,7 +225,7 @@ func (pm *PrinterManager) applyDiff(diff *lib.PrinterDiff, ch chan<- lib.Printer
 			log.InfoPrinterf(diff.Printer.Name+" "+diff.Printer.GCPID, "Registered in the cloud")
 
 			if pm.gcp.CanShare() {
-				if err := pm.gcp.Share(diff.Printer.GCPID, pm.shareScope, "USER", true); err != nil {
+				if err := pm.gcp.Share(diff.Printer.GCPID, pm.shareScope, gcp.User, true); err != nil {
 					log.ErrorPrinterf(diff.Printer.Name, "Failed to share: %s", err)
 				} else {
 					log.InfoPrinterf(diff.Printer.Name, "Shared")

--- a/manager/printermanager.go
+++ b/manager/printermanager.go
@@ -225,7 +225,7 @@ func (pm *PrinterManager) applyDiff(diff *lib.PrinterDiff, ch chan<- lib.Printer
 			log.InfoPrinterf(diff.Printer.Name+" "+diff.Printer.GCPID, "Registered in the cloud")
 
 			if pm.gcp.CanShare() {
-				if err := pm.gcp.Share(diff.Printer.GCPID, pm.shareScope); err != nil {
+				if err := pm.gcp.Share(diff.Printer.GCPID, pm.shareScope, "USER", true); err != nil {
 					log.ErrorPrinterf(diff.Printer.Name, "Failed to share: %s", err)
 				} else {
 					log.InfoPrinterf(diff.Printer.Name, "Shared")


### PR DESCRIPTION
-Add Unshare function to gcp.go:
  https://developers.google.com/cloud-print/docs/shareApi#unshare

-Extend Share function so that role and skip_notification parameters aren't static.

-Update printermanager.go (only caller of Share()) with new parameters. Keeps USER role and notifications off for sharing newly created printers.