### PR TITLE
Added printer name to log entry and added filter to ignore classes in cups

### DIFF
--- a/cups/core.go
+++ b/cups/core.go
@@ -191,8 +191,8 @@ func (cc *cupsCore) getPPD(printername *C.char, modtime *C.time_t) (*C.char, err
 		C.free(unsafe.Pointer(buffer))
 		cupsLastError := C.cupsLastError()
 		if cupsLastError != C.IPP_STATUS_OK {
-			return nil, fmt.Errorf("Failed to call cupsGetPPD3(): %d %s",
-				int(cupsLastError), C.GoString(C.cupsLastErrorString()))
+			return nil, fmt.Errorf("Failed to call cupsGetPPD3() for printer %s: %d %s",
+				C.GoString(printername), int(cupsLastError), C.GoString(C.cupsLastErrorString()))
 		}
 
 		return nil, fmt.Errorf("Failed to call cupsGetPPD3(); HTTP status: %d", int(httpStatus))

--- a/cups/core.go
+++ b/cups/core.go
@@ -191,8 +191,8 @@ func (cc *cupsCore) getPPD(printername *C.char, modtime *C.time_t) (*C.char, err
 		C.free(unsafe.Pointer(buffer))
 		cupsLastError := C.cupsLastError()
 		if cupsLastError != C.IPP_STATUS_OK {
-			return nil, fmt.Errorf("Failed to call cupsGetPPD3() for printer %s: %d %s",
-				C.GoString(printername), int(cupsLastError), C.GoString(C.cupsLastErrorString()))
+			return nil, fmt.Errorf("Failed to call cupsGetPPD3(): %d %s",
+				int(cupsLastError), C.GoString(C.cupsLastErrorString()))
 		}
 
 		return nil, fmt.Errorf("Failed to call cupsGetPPD3(); HTTP status: %d", int(httpStatus))

--- a/cups/cups.go
+++ b/cups/cups.go
@@ -312,7 +312,7 @@ func (c *CUPS) addPPDDescriptionToPrinters(printers []lib.Printer) []lib.Printer
 				p.Model = model
 				ch <- p
 			} else {
-				log.Error(err)
+				log.ErrorPrinter(p.Name, err)
 			}
 			wg.Done()
 		}(&printers[i])

--- a/cups/cups.go
+++ b/cups/cups.go
@@ -136,9 +136,11 @@ type CUPS struct {
 	printerAttributes     []string
 	systemTags            map[string]string
 	printerBlacklist      map[string]interface{}
+	ignoreRawPrinters     bool
+	ignoreClassPrinters   bool
 }
 
-func NewCUPS(infoToDisplayName, prefixJobIDToJobTitle bool, displayNamePrefix string, printerAttributes []string, maxConnections uint, connectTimeout time.Duration, printerBlacklist []string) (*CUPS, error) {
+func NewCUPS(infoToDisplayName, prefixJobIDToJobTitle bool, displayNamePrefix string, printerAttributes []string, maxConnections uint, connectTimeout time.Duration, printerBlacklist []string, ignoreRawPrinters bool, ignoreClassPrinters bool) (*CUPS, error) {
 	if err := checkPrinterAttributes(printerAttributes); err != nil {
 		return nil, err
 	}
@@ -160,13 +162,15 @@ func NewCUPS(infoToDisplayName, prefixJobIDToJobTitle bool, displayNamePrefix st
 	}
 
 	c := &CUPS{
-		cc:                cc,
-		pc:                pc,
-		infoToDisplayName: infoToDisplayName,
-		displayNamePrefix: displayNamePrefix,
-		printerAttributes: printerAttributes,
-		systemTags:        systemTags,
-		printerBlacklist:  pb,
+		cc:                  cc,
+		pc:                  pc,
+		infoToDisplayName:   infoToDisplayName,
+		displayNamePrefix:   displayNamePrefix,
+		printerAttributes:   printerAttributes,
+		systemTags:          systemTags,
+		printerBlacklist:    pb,
+		ignoreRawPrinters:   ignoreRawPrinters,
+		ignoreClassPrinters: ignoreClassPrinters,
 	}
 
 	return c, nil
@@ -209,7 +213,12 @@ func (c *CUPS) GetPrinters() ([]lib.Printer, error) {
 
 	printers := c.responseToPrinters(response)
 	printers = c.filterBlacklistPrinters(printers)
-	printers = filterRawPrinters(printers)
+	if c.ignoreRawPrinters {
+		printers = filterRawPrinters(printers)
+	}
+	if c.ignoreClassPrinters {
+		printers = filterClassPrinters(printers)
+	}
 	printers = c.addPPDDescriptionToPrinters(printers)
 	printers = addStaticDescriptionToPrinters(printers)
 
@@ -264,6 +273,17 @@ func (c *CUPS) filterBlacklistPrinters(printers []lib.Printer) []lib.Printer {
 		}
 	}
 	return result
+}
+
+// filterClassPrinters removes class printers from the slice.
+func filterClassPrinters(printers []lib.Printer) []lib.Printer {
+        result := make([]lib.Printer, 0, len(printers))
+        for i := range printers {
+                if !lib.PrinterIsClass(printers[i]) {
+                        result = append(result, printers[i])
+                }
+        }
+        return result
 }
 
 // filterRawPrinters removes raw printers from the slice.

--- a/gcp-cups-connector-util/gcp-cups-connector-util.go
+++ b/gcp-cups-connector-util/gcp-cups-connector-util.go
@@ -256,6 +256,11 @@ func updateConfigFile(context *cli.Context) {
 		fmt.Println("Added cups_job_full_username")
 		config.CUPSJobFullUsername = lib.DefaultConfig.CUPSJobFullUsername
 	}
+	if _, exists := configMap["cups_ignore_class_printers"]; !exists {
+		dirty = true
+		fmt.Println("Added cups_ignore_class_printers")
+		config.CUPSIgnoreClassPrinters = lib.DefaultConfig.CUPSIgnoreClassPrinters
+	}
 	if _, exists := configMap["cups_ignore_raw_printers"]; !exists {
 		dirty = true
 		fmt.Println("Added cups_ignore_raw_printers")

--- a/gcp-cups-connector-util/init.go
+++ b/gcp-cups-connector-util/init.go
@@ -99,6 +99,10 @@ var initFlags = []cli.Flag{
 		Usage: "Whether to ignore CUPS raw printers",
 	},
 	cli.BoolTFlag{
+		Name:  "cups-ignore-class-printers",
+		Usage: "Whether to ignore CUPS class printers",
+	},
+	cli.BoolTFlag{
 		Name:  "copy-printer-info-to-display-name",
 		Usage: "Whether to copy the CUPS printer's printer-info attribute to the GCP printer's defaultDisplayName",
 	},
@@ -346,6 +350,7 @@ func createCloudConfig(context *cli.Context, xmppJID, robotRefreshToken, userRef
 		CUPSPrinterAttributes:        lib.DefaultConfig.CUPSPrinterAttributes,
 		CUPSJobFullUsername:          context.Bool("cups-job-full-username"),
 		CUPSIgnoreRawPrinters:        context.Bool("cups-ignore-raw-printers"),
+		CUPSIgnoreClassPrinters:      context.Bool("cups-ignore-class-printers"),
 		CopyPrinterInfoToDisplayName: context.Bool("copy-printer-info-to-display-name"),
 		PrefixJobIDToJobTitle:        context.Bool("prefix-job-id-to-job-title"),
 		DisplayNamePrefix:            context.String("display-name-prefix"),
@@ -374,6 +379,7 @@ func createLocalConfig(context *cli.Context) *lib.Config {
 		CUPSPrinterAttributes:        lib.DefaultConfig.CUPSPrinterAttributes,
 		CUPSJobFullUsername:          context.Bool("cups-job-full-username"),
 		CUPSIgnoreRawPrinters:        context.Bool("cups-ignore-raw-printers"),
+		CUPSIgnoreClassPrinters:      context.Bool("cups-ignore-class-printers"),
 		CopyPrinterInfoToDisplayName: context.Bool("copy-printer-info-to-display-name"),
 		PrefixJobIDToJobTitle:        context.Bool("prefix-job-id-to-job-title"),
 		DisplayNamePrefix:            context.String("display-name-prefix"),

--- a/gcp-cups-connector/gcp-cups-connector.go
+++ b/gcp-cups-connector/gcp-cups-connector.go
@@ -152,7 +152,8 @@ func connector(context *cli.Context) int {
 	}
 	c, err := cups.NewCUPS(config.CopyPrinterInfoToDisplayName, config.PrefixJobIDToJobTitle,
 		config.DisplayNamePrefix, config.CUPSPrinterAttributes, config.CUPSMaxConnections,
-		cupsConnectTimeout, config.PrinterBlacklist)
+		cupsConnectTimeout, config.PrinterBlacklist, config.CUPSIgnoreRawPrinters,
+		config.CUPSIgnoreClassPrinters)
 	if err != nil {
 		log.Fatal(err)
 		return 1

--- a/lib/config.go
+++ b/lib/config.go
@@ -211,7 +211,7 @@ var DefaultConfig = Config{
 	},
 	CUPSJobFullUsername:          false,
 	CUPSIgnoreRawPrinters:        true,
-	CUPSIgnoreClassPrinters:      false,
+	CUPSIgnoreClassPrinters:      true,
 	CopyPrinterInfoToDisplayName: true,
 	PrefixJobIDToJobTitle:        false,
 	DisplayNamePrefix:            "",

--- a/lib/config.go
+++ b/lib/config.go
@@ -117,6 +117,9 @@ type Config struct {
 	// Whether to ignore printers with make/model 'Local Raw Printer'.
 	CUPSIgnoreRawPrinters bool `json:"cups_ignore_raw_printers"`
 
+	// Whether to ignore printers with make/model 'Local Printer Class'.
+	CUPSIgnoreClassPrinters bool `json:"cups_ignore_class_printers"`
+
 	// Whether to copy the CUPS printer's printer-info attribute to the GCP printer's defaultDisplayName.
 	CopyPrinterInfoToDisplayName bool `json:"copy_printer_info_to_display_name"`
 
@@ -208,6 +211,7 @@ var DefaultConfig = Config{
 	},
 	CUPSJobFullUsername:          false,
 	CUPSIgnoreRawPrinters:        true,
+	CUPSIgnoreClassPrinters:      false,
 	CopyPrinterInfoToDisplayName: true,
 	PrefixJobIDToJobTitle:        false,
 	DisplayNamePrefix:            "",

--- a/lib/printer.go
+++ b/lib/printer.go
@@ -236,3 +236,10 @@ func PrinterIsRaw(printer Printer) bool {
 	}
 	return false
 }
+
+func PrinterIsClass(printer Printer) bool {
+	if printer.Tags["printer-make-and-model"] == "Local Printer Class" {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Hello!

Please consider including this patch in your code.

I discovered that we had problems in our environment that the cups-connector failed to download some PPD files. I initially added print out of printer name in the getPPD function to be able to diagnose the problem (one of the commits). I discovered that some of our printers that are defined as classes failed to present a PPD file and none of the classes are really useful as cloudprint printers. So i added a function to filter out classes the same way the raw printers can be filtered including the configuration for it.
Doing this i discovered that the configuration to enable/disable ignoring raw printers was not passed to cups.go hence the raw printers was always ignored, i have added passing both the config to ignore raw printers and the new option to ignore classes.

I hope you find this useful and can consider adding this to your source. 

//Tomas Karlsson (tokarlss)