### PR TITLE
Fix dataraces on xmpp connection

### DIFF
--- a/xmpp/internal-xmpp.go
+++ b/xmpp/internal-xmpp.go
@@ -111,12 +111,15 @@ func newInternalXMPP(jid, accessToken, proxyName, server string, port uint16, pi
 	// dispatchIncoming signals pingPeriodically to return via dying.
 	dying := make(chan struct{})
 	go x.dispatchIncoming(dying)
-	go x.pingPeriodically(pingTimeout, pingInterval, dying)
 
 	// Check by ping
 	if success, err := x.ping(pingTimeout); !success {
+		x.Quit()
+		<-dying
 		return nil, fmt.Errorf("XMPP conversation started, but initial ping failed: %s", err)
 	}
+
+	go x.pingPeriodically(pingTimeout, pingInterval, dying)
 
 	return &x, nil
 }

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -71,16 +71,14 @@ func NewXMPP(jid, proxyName, server string, port uint16, pingTimeout, pingInterv
 
 // Quit terminates the XMPP conversation so that new jobs stop arriving.
 func (x *XMPP) Quit() {
-	if x.ix != nil {
-		// Signal to KeepXMPPAlive.
-		close(x.quit)
-		select {
-		case <-x.dead:
-			// Wait for XMPP to die.
-		case <-time.After(3 * time.Second):
-			// But not too long.
-			log.Error("XMPP taking a while to close, so giving up")
-		}
+	// Signal to KeepXMPPAlive.
+	close(x.quit)
+	select {
+	case <-x.dead:
+		// Wait for XMPP to die.
+	case <-time.After(3 * time.Second):
+		// But not too long.
+		log.Error("XMPP taking a while to close, so giving up")
 	}
 }
 
@@ -89,6 +87,7 @@ func (x *XMPP) Quit() {
 func (x *XMPP) startXMPP() error {
 	if x.ix != nil {
 		go x.ix.Quit()
+		x.ix = nil
 	}
 
 	password, err := x.getAccessToken()


### PR DESCRIPTION
Hi, I found 2 dataraces on xmpp package.

The one is occurred between `Quit` call by the main and restarting `internalXMPP` process by `keepXMPPAlive`.
I can't read why it checks `x.ix == nil` even if no one sets `nil`.

The other is occurred between the initial ping and `pingPeriodically` goroutine.
I think starting `pingPeriodically` in `newInternalXMPP` is too fast.

Since they are minor races, they may not effect the process but a bit notable so I'll record them as a pull request.

Here are warning logs by `go test -v -race`

```
=== RUN   TestXMPP_reconnect
I [13/Jan/2016:23:34:07 +0900] XMPP connection failed
E [13/Jan/2016:23:34:07 +0900] XMPP conversation died; restarting
I [13/Jan/2016:23:34:07 +0900] XMPP connection failed
==================
WARNING: DATA RACE
Write by goroutine 18:
  github.com/google/cups-connector/xmpp.(*XMPP).startXMPP()
      /gopath/src/github.com/google/cups-connector/xmpp/xmpp.go:105 +0x520
  github.com/google/cups-connector/xmpp.(*XMPP).keepXMPPAlive()
      /gopath/src/github.com/google/cups-connector/xmpp/xmpp.go:115 +0x1f1

Previous read by goroutine 13:
  github.com/google/cups-connector/xmpp.(*XMPP).Quit()
      /gopath/src/github.com/google/cups-connector/xmpp/xmpp.go:74 +0x54
  github.com/google/cups-connector/xmpp_test.TestXMPP_reconnect()
      /gopath/src/github.com/google/cups-connector/xmpp/xmpp_test.go:90 +0x5f7
  testing.tRunner()
      /tmp/workdir/go/src/testing/testing.go:456 +0xdc

Goroutine 18 (running) created at:
  github.com/google/cups-connector/xmpp.NewXMPP()
      /gopath/src/github.com/google/cups-connector/xmpp/xmpp.go:67 +0x239
  github.com/google/cups-connector/xmpp_test.TestXMPP_reconnect()
      /gopath/src/github.com/google/cups-connector/xmpp/xmpp_test.go:84 +0x483
  testing.tRunner()
      /tmp/workdir/go/src/testing/testing.go:456 +0xdc

Goroutine 13 (running) created at:
  testing.RunTests()
      /tmp/workdir/go/src/testing/testing.go:561 +0xaa3
  testing.(*M).Run()
      /tmp/workdir/go/src/testing/testing.go:494 +0xe4
  main.main()
      github.com/google/cups-connector/xmpp/_test/_testmain.go:58 +0x20f
==================
```

```
=== RUN   TestXMPP_ping
==================
WARNING: DATA RACE
Read by goroutine 44:
  github.com/google/cups-connector/xmpp.(*internalXMPP).ping()
      /gopath/src/github.com/google/cups-connector/xmpp/internal-xmpp.go:248 +0x86
  github.com/google/cups-connector/xmpp.(*internalXMPP).pingPeriodically()
      /gopath/src/github.com/google/cups-connector/xmpp/internal-xmpp.go:139 +0x146

Previous write by goroutine 42:
  github.com/google/cups-connector/xmpp.(*internalXMPP).ping()
      /gopath/src/github.com/google/cups-connector/xmpp/internal-xmpp.go:249 +0xc4
  github.com/google/cups-connector/xmpp.newInternalXMPP()
      /gopath/src/github.com/google/cups-connector/xmpp/internal-xmpp.go:117 +0x1253
  github.com/google/cups-connector/xmpp.(*XMPP).startXMPP()
      /gopath/src/github.com/google/cups-connector/xmpp/xmpp.go:99 +0x3b8
  github.com/google/cups-connector/xmpp.NewXMPP()
      /gopath/src/github.com/google/cups-connector/xmpp/xmpp.go:63 +0x1d4
  github.com/google/cups-connector/xmpp_test.TestXMPP_ping()
      /gopath/src/github.com/google/cups-connector/xmpp/xmpp_test.go:119 +0x4a1
  testing.tRunner()
      /tmp/workdir/go/src/testing/testing.go:456 +0xdc
```
