### PR TITLE
Fix init bug.

### DIFF
--- a/gcp-connector-util/init.go
+++ b/gcp-connector-util/init.go
@@ -370,6 +370,9 @@ func initConfigFile(context *cli.Context) {
 		var userClient *http.Client
 		if context.IsSet("gcp-user-refresh-token") {
 			userClient = getUserClientFromToken(context)
+			if shareScope != "" {
+				userRefreshToken = context.String("gcp-user-refresh-token")
+			}
 		} else {
 			var urt string
 			userClient, urt = getUserClientFromUser(context)


### PR DESCRIPTION
When --gcp-user-refresh-token and --share-scope are specified, the user
refresh token wasn't set in the resulting config file.