### PR TITLE
windows: Remove XDG dependency.

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -12,13 +12,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path/filepath"
 	"runtime"
 
 	"github.com/codegangsta/cli"
-
-	"launchpad.net/go-xdg/v0"
 )
 
 const (
@@ -129,41 +125,6 @@ type commonConfig struct {
 
 	// Least severity to log.
 	LogLevel string `json:"log_level"`
-}
-
-// getConfigFilename gets the absolute filename of the config file specified by
-// the ConfigFilename flag, and whether it exists.
-//
-// If the (relative or absolute) ConfigFilename exists, then it is returned.
-// If the ConfigFilename exists in a valid XDG path, then it is returned.
-// If neither of those exist, the (relative or absolute) ConfigFilename is returned.
-func getConfigFilename(context *cli.Context) (string, bool) {
-	cf := context.GlobalString("config-filename")
-
-	if filepath.IsAbs(cf) {
-		// Absolute path specified; user knows what they want.
-		_, err := os.Stat(cf)
-		return cf, err == nil
-	}
-
-	absCF, err := filepath.Abs(cf)
-	if err != nil {
-		// syscall failure; treat as if file doesn't exist.
-		return cf, false
-	}
-	if _, err := os.Stat(absCF); err == nil {
-		// File exists on relative path.
-		return absCF, true
-	}
-
-	if xdgCF, err := xdg.Config.Find(cf); err == nil {
-		// File exists in an XDG directory.
-		return xdgCF, true
-	}
-
-	// Default to relative path. This is probably what the user expects if
-	// it wasn't found anywhere else.
-	return absCF, false
 }
 
 // GetConfig reads a Config object from the config file indicated by the config


### PR DESCRIPTION
Windows doesn't benefit from XDG, and it doesn't install nicely like git dependencies (the XDG libarary lives in a bzr repository).