### PR TITLE
Read/write sparse config files.

### DIFF
--- a/gcp-connector-util/init.go
+++ b/gcp-connector-util/init.go
@@ -100,7 +100,7 @@ var commonInitFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "log-level",
-		Usage: "Minimum event severity to log: PANIC, ERROR, WARN, INFO, DEBUG, VERBOSE",
+		Usage: "Minimum event severity to log: FATAL, ERROR, WARNING, INFO, DEBUG",
 		Value: lib.DefaultConfig.LogLevel,
 	},
 }
@@ -262,7 +262,7 @@ func createRobotAccount(context *cli.Context, userClient *http.Client) (string, 
 }
 
 func writeConfigFile(context *cli.Context, config *lib.Config) string {
-	if configFilename, err := config.ToFile(context); err != nil {
+	if configFilename, err := config.Sparse(context).ToFile(context); err != nil {
 		log.Fatalln(err)
 	} else {
 		return configFilename

--- a/gcp-connector-util/main_windows.go
+++ b/gcp-connector-util/main_windows.go
@@ -61,10 +61,6 @@ var windowsCommands = []cli.Command{
 	},
 }
 
-func updateConfig(config *lib.Config, configMap map[string]interface{}) bool {
-	return commonUpdateConfig(config, configMap)
-}
-
 func installEventLog(c *cli.Context) {
 	err := eventlog.InstallAsEventCreate(lib.ConnectorName, eventlog.Error|eventlog.Warning|eventlog.Info)
 	if err != nil {
@@ -204,6 +200,9 @@ func main() {
 // createCloudConfig creates a config object that supports cloud and (optionally) local mode.
 func createCloudConfig(context *cli.Context, xmppJID, robotRefreshToken, userRefreshToken, shareScope, proxyName string, localEnable bool) *lib.Config {
 	return &lib.Config{
+		LocalPrintingEnable: localEnable,
+		CloudPrintingEnable: true,
+
 		XMPPJID:                   xmppJID,
 		RobotRefreshToken:         robotRefreshToken,
 		UserRefreshToken:          userRefreshToken,
@@ -222,11 +221,9 @@ func createCloudConfig(context *cli.Context, xmppJID, robotRefreshToken, userRef
 
 		NativeJobQueueSize:        uint(context.Int("native-job-queue-size")),
 		NativePrinterPollInterval: context.String("native-printer-poll-interval"),
-		PrefixJobIDToJobTitle:     context.Bool("prefix-job-id-to-job-title"),
+		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,
-		LocalPrintingEnable:       localEnable,
-		CloudPrintingEnable:       true,
 		LogLevel:                  context.String("log-level"),
 	}
 }
@@ -234,13 +231,14 @@ func createCloudConfig(context *cli.Context, xmppJID, robotRefreshToken, userRef
 // createLocalConfig creates a config object that supports local mode.
 func createLocalConfig(context *cli.Context) *lib.Config {
 	return &lib.Config{
+		LocalPrintingEnable: true,
+		CloudPrintingEnable: false,
+
 		NativeJobQueueSize:        uint(context.Int("native-job-queue-size")),
 		NativePrinterPollInterval: context.String("native-printer-poll-interval"),
-		PrefixJobIDToJobTitle:     context.Bool("prefix-job-id-to-job-title"),
+		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,
-		LocalPrintingEnable:       true,
-		CloudPrintingEnable:       false,
 		LogLevel:                  context.String("log-level"),
 	}
 }

--- a/gcp-cups-connector/gcp-cups-connector.go
+++ b/gcp-cups-connector/gcp-cups-connector.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -54,7 +55,7 @@ func connector(context *cli.Context) int {
 		return 1
 	}
 
-	logToJournal := config.LogToJournal && journal.Enabled()
+	logToJournal := *config.LogToJournal && journal.Enabled()
 	logToConsole := context.Bool("log-to-console")
 
 	if logToJournal {
@@ -91,6 +92,8 @@ func connector(context *cli.Context) int {
 	} else {
 		log.Infof("Using config file %s", configFilename)
 	}
+	completeConfig, _ := json.MarshalIndent(config, "", " ")
+	log.Debugf("Config: %s", string(completeConfig))
 
 	log.Info(lib.FullName)
 	fmt.Println(lib.FullName)
@@ -151,10 +154,10 @@ func connector(context *cli.Context) int {
 		log.Fatalf("Failed to parse CUPS connect timeout: %s", err)
 		return 1
 	}
-	c, err := cups.NewCUPS(config.CUPSCopyPrinterInfoToDisplayName, config.PrefixJobIDToJobTitle,
+	c, err := cups.NewCUPS(*config.CUPSCopyPrinterInfoToDisplayName, *config.PrefixJobIDToJobTitle,
 		config.DisplayNamePrefix, config.CUPSPrinterAttributes, config.CUPSMaxConnections,
-		cupsConnectTimeout, config.PrinterBlacklist, config.CUPSIgnoreRawPrinters,
-		config.CUPSIgnoreClassPrinters)
+		cupsConnectTimeout, config.PrinterBlacklist, *config.CUPSIgnoreRawPrinters,
+		*config.CUPSIgnoreClassPrinters)
 	if err != nil {
 		log.Fatal(err)
 		return 1
@@ -181,7 +184,7 @@ func connector(context *cli.Context) int {
 		return 1
 	}
 	pm, err := manager.NewPrinterManager(c, g, priv, nativePrinterPollInterval,
-		config.NativeJobQueueSize, config.CUPSJobFullUsername, config.ShareScope,
+		config.NativeJobQueueSize, *config.CUPSJobFullUsername, config.ShareScope,
 		jobs, xmppNotifications)
 	if err != nil {
 		log.Fatal(err)

--- a/gcp-windows-connector/gcp-windows-connector.go
+++ b/gcp-windows-connector/gcp-windows-connector.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -100,6 +101,8 @@ func (service *service) Execute(args []string, r <-chan svc.ChangeRequest, s cha
 	} else {
 		log.Infof("Using config file %s", configFilename)
 	}
+	completeConfig, _ := json.MarshalIndent(config, "", " ")
+	log.Debugf("Config: %s", string(completeConfig))
 
 	log.Info(lib.FullName)
 
@@ -146,7 +149,7 @@ func (service *service) Execute(args []string, r <-chan svc.ChangeRequest, s cha
 		defer x.Quit()
 	}
 
-	ws, err := winspool.NewWinSpool(config.PrefixJobIDToJobTitle, config.DisplayNamePrefix, config.PrinterBlacklist)
+	ws, err := winspool.NewWinSpool(*config.PrefixJobIDToJobTitle, config.DisplayNamePrefix, config.PrinterBlacklist)
 	if err != nil {
 		log.Fatal(err)
 		return false, 1

--- a/lib/config.go
+++ b/lib/config.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"reflect"
 	"runtime"
 
 	"github.com/codegangsta/cli"
@@ -42,6 +43,11 @@ var (
 	FullName = ConnectorName + " for " + platformName + " version " + BuildDate + "-" + runtime.GOOS
 )
 
+// PointerToBool converts a boolean value (constant) to a pointer-to-bool.
+func PointerToBool(b bool) *bool {
+	return &b
+}
+
 // GetConfig reads a Config object from the config file indicated by the config
 // filename flag. If no such file exists, then DefaultConfig is returned.
 func GetConfig(context *cli.Context) (*Config, string, error) {
@@ -50,16 +56,25 @@ func GetConfig(context *cli.Context) (*Config, string, error) {
 		return &DefaultConfig, "", nil
 	}
 
-	b, err := ioutil.ReadFile(cf)
+	configRaw, err := ioutil.ReadFile(cf)
 	if err != nil {
 		return nil, "", err
 	}
 
-	var config Config
-	if err = json.Unmarshal(b, &config); err != nil {
+	config := new(Config)
+	if err = json.Unmarshal(configRaw, config); err != nil {
 		return nil, "", err
 	}
-	return &config, cf, nil
+
+	// Same config as a map so that we can detect missing keys.
+	var configMap map[string]interface{}
+	if err = json.Unmarshal(configRaw, &configMap); err != nil {
+		return nil, "", err
+	}
+
+	b := config.Backfill(configMap)
+
+	return b, cf, nil
 }
 
 // ToFile writes this Config object to the config file indicated by ConfigFile.
@@ -74,4 +89,122 @@ func (c *Config) ToFile(context *cli.Context) (string, error) {
 		return "", err
 	}
 	return cf, nil
+}
+
+func (c *Config) commonSparse(context *cli.Context) *Config {
+	s := *c
+
+	if s.XMPPServer == DefaultConfig.XMPPServer {
+		s.XMPPServer = ""
+	}
+	if !context.IsSet("xmpp-port") &&
+		s.XMPPPort == DefaultConfig.XMPPPort {
+		s.XMPPPort = 0
+	}
+	if !context.IsSet("xmpp-ping-timeout") &&
+		s.XMPPPingTimeout == DefaultConfig.XMPPPingTimeout {
+		s.XMPPPingTimeout = ""
+	}
+	if !context.IsSet("xmpp-ping-interval") &&
+		s.XMPPPingInterval == DefaultConfig.XMPPPingInterval {
+		s.XMPPPingInterval = ""
+	}
+	if s.GCPBaseURL == DefaultConfig.GCPBaseURL {
+		s.GCPBaseURL = ""
+	}
+	if s.GCPOAuthClientID == DefaultConfig.GCPOAuthClientID {
+		s.GCPOAuthClientID = ""
+	}
+	if s.GCPOAuthClientSecret == DefaultConfig.GCPOAuthClientSecret {
+		s.GCPOAuthClientSecret = ""
+	}
+	if s.GCPOAuthAuthURL == DefaultConfig.GCPOAuthAuthURL {
+		s.GCPOAuthAuthURL = ""
+	}
+	if s.GCPOAuthTokenURL == DefaultConfig.GCPOAuthTokenURL {
+		s.GCPOAuthTokenURL = ""
+	}
+	if !context.IsSet("gcp-max-concurrent-downloads") &&
+		s.GCPMaxConcurrentDownloads == DefaultConfig.GCPMaxConcurrentDownloads {
+		s.GCPMaxConcurrentDownloads = 0
+	}
+	if !context.IsSet("native-job-queue-size") &&
+		s.NativeJobQueueSize == DefaultConfig.NativeJobQueueSize {
+		s.NativeJobQueueSize = 0
+	}
+	if !context.IsSet("native-printer-poll-interval") &&
+		s.NativePrinterPollInterval == DefaultConfig.NativePrinterPollInterval {
+		s.NativePrinterPollInterval = ""
+	}
+	if !context.IsSet("prefix-job-id-to-job-title") &&
+		reflect.DeepEqual(s.PrefixJobIDToJobTitle, DefaultConfig.PrefixJobIDToJobTitle) {
+		s.PrefixJobIDToJobTitle = nil
+	}
+	if !context.IsSet("display-name-prefix") &&
+		s.DisplayNamePrefix == DefaultConfig.DisplayNamePrefix {
+		s.DisplayNamePrefix = ""
+	}
+
+	return &s
+}
+
+func (c *Config) commonBackfill(configMap map[string]interface{}) *Config {
+	b := *c
+
+	if _, exists := configMap["xmpp_server"]; !exists {
+		b.XMPPServer = DefaultConfig.XMPPServer
+	}
+	if _, exists := configMap["xmpp_port"]; !exists {
+		b.XMPPPort = DefaultConfig.XMPPPort
+	}
+	if _, exists := configMap["gcp_xmpp_ping_timeout"]; !exists {
+		b.XMPPPingTimeout = DefaultConfig.XMPPPingTimeout
+	}
+	if _, exists := configMap["gcp_xmpp_ping_interval_default"]; !exists {
+		b.XMPPPingInterval = DefaultConfig.XMPPPingInterval
+	}
+	if _, exists := configMap["gcp_base_url"]; !exists {
+		b.GCPBaseURL = DefaultConfig.GCPBaseURL
+	}
+	if _, exists := configMap["gcp_oauth_client_id"]; !exists {
+		b.GCPOAuthClientID = DefaultConfig.GCPOAuthClientID
+	}
+	if _, exists := configMap["gcp_oauth_client_secret"]; !exists {
+		b.GCPOAuthClientSecret = DefaultConfig.GCPOAuthClientSecret
+	}
+	if _, exists := configMap["gcp_oauth_auth_url"]; !exists {
+		b.GCPOAuthAuthURL = DefaultConfig.GCPOAuthAuthURL
+	}
+	if _, exists := configMap["gcp_oauth_token_url"]; !exists {
+		b.GCPOAuthTokenURL = DefaultConfig.GCPOAuthTokenURL
+	}
+	if _, exists := configMap["gcp_max_concurrent_downloads"]; !exists {
+		b.GCPMaxConcurrentDownloads = DefaultConfig.GCPMaxConcurrentDownloads
+	}
+	if _, exists := configMap["cups_job_queue_size"]; !exists {
+		b.NativeJobQueueSize = DefaultConfig.NativeJobQueueSize
+	}
+	if _, exists := configMap["cups_printer_poll_interval"]; !exists {
+		b.NativePrinterPollInterval = DefaultConfig.NativePrinterPollInterval
+	}
+	if _, exists := configMap["prefix_job_id_to_job_title"]; !exists {
+		b.PrefixJobIDToJobTitle = DefaultConfig.PrefixJobIDToJobTitle
+	}
+	if _, exists := configMap["display_name_prefix"]; !exists {
+		b.DisplayNamePrefix = DefaultConfig.DisplayNamePrefix
+	}
+	if _, exists := configMap["printer_blacklist"]; !exists {
+		b.PrinterBlacklist = DefaultConfig.PrinterBlacklist
+	}
+	if _, exists := configMap["local_printing_enable"]; !exists {
+		b.LocalPrintingEnable = DefaultConfig.LocalPrintingEnable
+	}
+	if _, exists := configMap["cloud_printing_enable"]; !exists {
+		b.CloudPrintingEnable = DefaultConfig.CloudPrintingEnable
+	}
+	if _, exists := configMap["log_level"]; !exists {
+		b.LogLevel = DefaultConfig.LogLevel
+	}
+
+	return &b
 }

--- a/lib/config_unix.go
+++ b/lib/config_unix.go
@@ -11,6 +11,7 @@ package lib
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 
 	"github.com/codegangsta/cli"
 	"launchpad.net/go-xdg/v0"
@@ -23,6 +24,12 @@ const (
 )
 
 type Config struct {
+	// Enable local discovery and printing.
+	LocalPrintingEnable bool `json:"local_printing_enable"`
+
+	// Enable cloud discovery and printing.
+	CloudPrintingEnable bool `json:"cloud_printing_enable"`
+
 	// Associated with root account. XMPP credential.
 	XMPPJID string `json:"xmpp_jid,omitempty"`
 
@@ -71,28 +78,22 @@ type Config struct {
 	// Maximum quantity of jobs (data) to download concurrently.
 	GCPMaxConcurrentDownloads uint `json:"gcp_max_concurrent_downloads,omitempty"`
 
-	// CUPS job queue size.
+	// CUPS job queue size, must be greater than zero.
 	// TODO: rename without cups_ prefix
-	NativeJobQueueSize uint `json:"cups_job_queue_size"`
+	NativeJobQueueSize uint `json:"cups_job_queue_size,omitempty"`
 
 	// Interval (eg 10s, 1m) between CUPS printer state polls.
 	// TODO: rename without cups_ prefix
-	NativePrinterPollInterval string `json:"cups_printer_poll_interval"`
+	NativePrinterPollInterval string `json:"cups_printer_poll_interval,omitempty"`
 
 	// Add the job ID to the beginning of the job title. Useful for debugging.
-	PrefixJobIDToJobTitle bool `json:"prefix_job_id_to_job_title"`
+	PrefixJobIDToJobTitle *bool `json:"prefix_job_id_to_job_title,omitempty"`
 
 	// Prefix for all GCP printers hosted by this connector.
-	DisplayNamePrefix string `json:"display_name_prefix"`
+	DisplayNamePrefix string `json:"display_name_prefix,omitempty"`
 
 	// Ignore printers with native names.
-	PrinterBlacklist []string `json:"printer_blacklist"`
-
-	// Enable local discovery and printing.
-	LocalPrintingEnable bool `json:"local_printing_enable"`
-
-	// Enable cloud discovery and printing.
-	CloudPrintingEnable bool `json:"cloud_printing_enable"`
+	PrinterBlacklist []string `json:"printer_blacklist,omitempty"`
 
 	// Least severity to log.
 	LogLevel string `json:"log_level"`
@@ -101,16 +102,16 @@ type Config struct {
 	LogFileName string `json:"log_file_name"`
 
 	// CUPS only: Maximum log file size.
-	LogFileMaxMegabytes uint `json:"log_file_max_megabytes"`
+	LogFileMaxMegabytes uint `json:"log_file_max_megabytes,omitempty"`
 
 	// CUPS only: Maximum log file quantity.
-	LogMaxFiles uint `json:"log_max_files"`
+	LogMaxFiles uint `json:"log_max_files,omitempty"`
 
 	// CUPS only: Log to the systemd journal instead of to files?
-	LogToJournal bool `json:"log_to_journal"`
+	LogToJournal *bool `json:"log_to_journal,omitempty"`
 
 	// CUPS only: Filename of unix socket for connector-check to talk to connector.
-	MonitorSocketFilename string `json:"monitor_socket_filename"`
+	MonitorSocketFilename string `json:"monitor_socket_filename,omitempty"`
 
 	// CUPS only: Maximum quantity of open CUPS connections.
 	CUPSMaxConnections uint `json:"cups_max_connections,omitempty"`
@@ -122,23 +123,26 @@ type Config struct {
 	CUPSPrinterAttributes []string `json:"cups_printer_attributes,omitempty"`
 
 	// CUPS only: use the full username (joe@example.com) in CUPS job.
-	CUPSJobFullUsername bool `json:"cups_job_full_username,omitempty"`
+	CUPSJobFullUsername *bool `json:"cups_job_full_username,omitempty"`
 
 	// CUPS only: ignore printers with make/model 'Local Raw Printer'.
-	CUPSIgnoreRawPrinters bool `json:"cups_ignore_raw_printers"`
+	CUPSIgnoreRawPrinters *bool `json:"cups_ignore_raw_printers,omitempty"`
 
 	// CUPS only: ignore printers with make/model 'Local Printer Class'.
-	CUPSIgnoreClassPrinters bool `json:"cups_ignore_class_printers"`
+	CUPSIgnoreClassPrinters *bool `json:"cups_ignore_class_printers,omitempty"`
 
 	// CUPS only: copy the CUPS printer's printer-info attribute to the GCP printer's defaultDisplayName.
 	// TODO: rename with cups_ prefix
-	CUPSCopyPrinterInfoToDisplayName bool `json:"copy_printer_info_to_display_name,omitempty"`
+	CUPSCopyPrinterInfoToDisplayName *bool `json:"copy_printer_info_to_display_name,omitempty"`
 }
 
 // DefaultConfig represents reasonable default values for Config fields.
 // Omitted Config fields are omitted on purpose; they are unique per
 // connector instance.
 var DefaultConfig = Config{
+	LocalPrintingEnable: true,
+	CloudPrintingEnable: false,
+
 	XMPPServer:                "talk.google.com",
 	XMPPPort:                  443,
 	XMPPPingTimeout:           "5s",
@@ -152,17 +156,15 @@ var DefaultConfig = Config{
 
 	NativeJobQueueSize:        3,
 	NativePrinterPollInterval: "1m",
-	PrefixJobIDToJobTitle:     false,
+	PrefixJobIDToJobTitle:     PointerToBool(false),
 	DisplayNamePrefix:         "",
 	PrinterBlacklist:          []string{},
-	LocalPrintingEnable:       true,
-	CloudPrintingEnable:       false,
 	LogLevel:                  "INFO",
 
 	LogFileName:         "/tmp/cups-connector",
 	LogFileMaxMegabytes: 1,
 	LogMaxFiles:         3,
-	LogToJournal:        false,
+	LogToJournal:        PointerToBool(false),
 
 	MonitorSocketFilename: "/tmp/cups-connector-monitor.sock",
 
@@ -192,10 +194,10 @@ var DefaultConfig = Config{
 		"orientation-requested-supported",
 		"pdf-versions-supported",
 	},
-	CUPSJobFullUsername:              false,
-	CUPSIgnoreRawPrinters:            true,
-	CUPSIgnoreClassPrinters:          true,
-	CUPSCopyPrinterInfoToDisplayName: true,
+	CUPSJobFullUsername:              PointerToBool(false),
+	CUPSIgnoreRawPrinters:            PointerToBool(true),
+	CUPSIgnoreClassPrinters:          PointerToBool(true),
+	CUPSCopyPrinterInfoToDisplayName: PointerToBool(true),
 }
 
 // getConfigFilename gets the absolute filename of the config file specified by
@@ -231,4 +233,110 @@ func getConfigFilename(context *cli.Context) (string, bool) {
 	// Default to relative path. This is probably what the user expects if
 	// it wasn't found anywhere else.
 	return absCF, false
+}
+
+// Backfill returns a copy of this config with all missing keys set to default values.
+func (c *Config) Backfill(configMap map[string]interface{}) *Config {
+	b := *c.commonBackfill(configMap)
+
+	if _, exists := configMap["log_file_name"]; !exists {
+		b.LogFileName = DefaultConfig.LogFileName
+	}
+	if _, exists := configMap["log_file_max_megabytes"]; !exists {
+		b.LogFileMaxMegabytes = DefaultConfig.LogFileMaxMegabytes
+	}
+	if _, exists := configMap["log_max_files"]; !exists {
+		b.LogMaxFiles = DefaultConfig.LogMaxFiles
+	}
+	if _, exists := configMap["log_to_journal"]; !exists {
+		b.LogToJournal = DefaultConfig.LogToJournal
+	}
+	if _, exists := configMap["monitor_socket_filename"]; !exists {
+		b.MonitorSocketFilename = DefaultConfig.MonitorSocketFilename
+	}
+	if _, exists := configMap["cups_max_connections"]; !exists {
+		b.CUPSMaxConnections = DefaultConfig.CUPSMaxConnections
+	}
+	if _, exists := configMap["cups_connect_timeout"]; !exists {
+		b.CUPSConnectTimeout = DefaultConfig.CUPSConnectTimeout
+	}
+	if _, exists := configMap["cups_printer_attributes"]; !exists {
+		b.CUPSPrinterAttributes = DefaultConfig.CUPSPrinterAttributes
+	} else {
+		// Make sure all required attributes are present.
+		s := make(map[string]struct{}, len(b.CUPSPrinterAttributes))
+		for _, a := range b.CUPSPrinterAttributes {
+			s[a] = struct{}{}
+		}
+		for _, a := range DefaultConfig.CUPSPrinterAttributes {
+			if _, exists := s[a]; !exists {
+				b.CUPSPrinterAttributes = append(b.CUPSPrinterAttributes, a)
+			}
+		}
+	}
+	if _, exists := configMap["cups_job_full_username"]; !exists {
+		b.CUPSJobFullUsername = DefaultConfig.CUPSJobFullUsername
+	}
+	if _, exists := configMap["cups_ignore_raw_printers"]; !exists {
+		b.CUPSIgnoreRawPrinters = DefaultConfig.CUPSIgnoreRawPrinters
+	}
+	if _, exists := configMap["cups_ignore_class_printers"]; !exists {
+		b.CUPSIgnoreClassPrinters = DefaultConfig.CUPSIgnoreClassPrinters
+	}
+	if _, exists := configMap["copy_printer_info_to_display_name"]; !exists {
+		b.CUPSCopyPrinterInfoToDisplayName = DefaultConfig.CUPSCopyPrinterInfoToDisplayName
+	}
+
+	return &b
+}
+
+// Sparse returns a copy of this config with obvious values removed.
+func (c *Config) Sparse(context *cli.Context) *Config {
+	s := *c.commonSparse(context)
+
+	if !context.IsSet("log-file-max-megabytes") &&
+		s.LogFileMaxMegabytes == DefaultConfig.LogFileMaxMegabytes {
+		s.LogFileMaxMegabytes = 0
+	}
+	if !context.IsSet("log-max-files") &&
+		s.LogMaxFiles == DefaultConfig.LogMaxFiles {
+		s.LogMaxFiles = 0
+	}
+	if !context.IsSet("log-to-journal") &&
+		reflect.DeepEqual(s.LogToJournal, DefaultConfig.LogToJournal) {
+		s.LogToJournal = nil
+	}
+	if !context.IsSet("monitor-socket-filename") &&
+		s.MonitorSocketFilename == DefaultConfig.MonitorSocketFilename {
+		s.MonitorSocketFilename = ""
+	}
+	if !context.IsSet("cups-max-connections") &&
+		s.CUPSMaxConnections == DefaultConfig.CUPSMaxConnections {
+		s.CUPSMaxConnections = 0
+	}
+	if !context.IsSet("cups-connect-timeout") &&
+		s.CUPSConnectTimeout == DefaultConfig.CUPSConnectTimeout {
+		s.CUPSConnectTimeout = ""
+	}
+	if reflect.DeepEqual(s.CUPSPrinterAttributes, DefaultConfig.CUPSPrinterAttributes) {
+		s.CUPSPrinterAttributes = nil
+	}
+	if !context.IsSet("cups-job-full-username") &&
+		reflect.DeepEqual(s.CUPSJobFullUsername, DefaultConfig.CUPSJobFullUsername) {
+		s.CUPSJobFullUsername = nil
+	}
+	if !context.IsSet("cups-ignore-raw-printers") &&
+		reflect.DeepEqual(s.CUPSIgnoreRawPrinters, DefaultConfig.CUPSIgnoreRawPrinters) {
+		s.CUPSIgnoreRawPrinters = nil
+	}
+	if !context.IsSet("cups-ignore-class-printers") &&
+		reflect.DeepEqual(s.CUPSIgnoreClassPrinters, DefaultConfig.CUPSIgnoreClassPrinters) {
+		s.CUPSIgnoreClassPrinters = nil
+	}
+	if !context.IsSet("copy-printer-info-to-display-name") &&
+		reflect.DeepEqual(s.CUPSCopyPrinterInfoToDisplayName, DefaultConfig.CUPSCopyPrinterInfoToDisplayName) {
+		s.CUPSCopyPrinterInfoToDisplayName = nil
+	}
+
+	return &s
 }


### PR DESCRIPTION
Replaced utility update-config-file with backfill-config-file and
sparse-config-file. Utility init now creates a config file that is
sparse, except for user-specified values that are != default values.

Fixes #125