### PR TITLE
Implemented cups_job_full_username option in Windows port (and more)

### DIFF
--- a/cups/cups.go
+++ b/cups/cups.go
@@ -399,7 +399,7 @@ func (c *CUPS) RemoveCachedPPD(printername string) {
 }
 
 // GetJobState gets the current state of the job indicated by jobID.
-func (c *CUPS) GetJobState(_ string, jobID uint32) (*cdd.PrintJobStateDiff, error) {
+func (c *CUPS) GetJobState(_ string, jobID uint32, jobSpooledIsDone bool) (*cdd.PrintJobStateDiff, error) {
 	ja := C.newArrayOfStrings(C.int(len(jobAttributes)))
 	defer C.freeStringArrayAndStrings(ja, C.int(len(jobAttributes)))
 	for i, attribute := range jobAttributes {

--- a/gcp-connector-util/main_windows.go
+++ b/gcp-connector-util/main_windows.go
@@ -221,13 +221,12 @@ func createCloudConfig(context *cli.Context, xmppJID, robotRefreshToken, userRef
 
 		NativeJobQueueSize:        uint(context.Int("native-job-queue-size")),
 		NativePrinterPollInterval: context.String("native-printer-poll-interval"),
+		CUPSJobFullUsername:       lib.PointerToBool(context.Bool("cups-job-full-username")),
+		JobSpooledIsDone:          lib.PointerToBool(context.Bool("job-spooled-is-done")),
 		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,
 		LogLevel:                  context.String("log-level"),
-
-		LocalPortLow:  uint16(context.Int("local-port-low")),
-		LocalPortHigh: uint16(context.Int("local-port-high")),
 	}
 }
 
@@ -239,12 +238,11 @@ func createLocalConfig(context *cli.Context) *lib.Config {
 
 		NativeJobQueueSize:        uint(context.Int("native-job-queue-size")),
 		NativePrinterPollInterval: context.String("native-printer-poll-interval"),
+		CUPSJobFullUsername:       lib.PointerToBool(context.Bool("cups-job-full-username")),
+		JobSpooledIsDone:          lib.PointerToBool(context.Bool("job-spooled-is-done")),
 		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,
 		LogLevel:                  context.String("log-level"),
-
-		LocalPortLow:  uint16(context.Int("local-port-low")),
-		LocalPortHigh: uint16(context.Int("local-port-high")),
 	}
 }

--- a/gcp-cups-connector/gcp-cups-connector.go
+++ b/gcp-cups-connector/gcp-cups-connector.go
@@ -167,9 +167,9 @@ func connector(context *cli.Context) int {
 	var priv *privet.Privet
 	if config.LocalPrintingEnable {
 		if g == nil {
-			priv, err = privet.NewPrivet(jobs, config.LocalPortLow, config.LocalPortHigh, config.GCPBaseURL, nil)
+			priv, err = privet.NewPrivet(jobs, config.GCPBaseURL, nil)
 		} else {
-			priv, err = privet.NewPrivet(jobs, config.LocalPortLow, config.LocalPortHigh, config.GCPBaseURL, g.ProximityToken)
+			priv, err = privet.NewPrivet(jobs, config.GCPBaseURL, g.ProximityToken)
 		}
 		if err != nil {
 			log.Fatal(err)
@@ -184,7 +184,7 @@ func connector(context *cli.Context) int {
 		return 1
 	}
 	pm, err := manager.NewPrinterManager(c, g, priv, nativePrinterPollInterval,
-		config.NativeJobQueueSize, *config.CUPSJobFullUsername, config.ShareScope,
+		config.NativeJobQueueSize, *config.CUPSJobFullUsername, false, config.ShareScope,
 		jobs, xmppNotifications)
 	if err != nil {
 		log.Fatal(err)

--- a/gcp-windows-connector/gcp-windows-connector.go
+++ b/gcp-windows-connector/gcp-windows-connector.go
@@ -161,7 +161,7 @@ func (service *service) Execute(args []string, r <-chan svc.ChangeRequest, s cha
 		return false, 1
 	}
 	pm, err := manager.NewPrinterManager(ws, g, nil, nativePrinterPollInterval,
-		config.NativeJobQueueSize, false, config.ShareScope, jobs, xmppNotifications)
+		config.NativeJobQueueSize, *config.CUPSJobFullUsername, *config.JobSpooledIsDone, config.ShareScope, jobs, xmppNotifications)
 	if err != nil {
 		log.Fatal(err)
 		return false, 1

--- a/lib/config.go
+++ b/lib/config.go
@@ -136,6 +136,14 @@ func (c *Config) commonSparse(context *cli.Context) *Config {
 		s.NativePrinterPollInterval == DefaultConfig.NativePrinterPollInterval {
 		s.NativePrinterPollInterval = ""
 	}
+	if !context.IsSet("cups-job-full-username") &&
+		reflect.DeepEqual(s.CUPSJobFullUsername, DefaultConfig.CUPSJobFullUsername) {
+		s.CUPSJobFullUsername = nil
+	}
+	if !context.IsSet("job-spooled-is-done") &&
+		reflect.DeepEqual(s.JobSpooledIsDone, DefaultConfig.JobSpooledIsDone) {
+		s.JobSpooledIsDone = nil
+	}
 	if !context.IsSet("prefix-job-id-to-job-title") &&
 		reflect.DeepEqual(s.PrefixJobIDToJobTitle, DefaultConfig.PrefixJobIDToJobTitle) {
 		s.PrefixJobIDToJobTitle = nil
@@ -143,14 +151,6 @@ func (c *Config) commonSparse(context *cli.Context) *Config {
 	if !context.IsSet("display-name-prefix") &&
 		s.DisplayNamePrefix == DefaultConfig.DisplayNamePrefix {
 		s.DisplayNamePrefix = ""
-	}
-	if !context.IsSet("local-port-low") &&
-		s.LocalPortLow == DefaultConfig.LocalPortLow {
-		s.LocalPortLow = 0
-	}
-	if !context.IsSet("local-port-high") &&
-		s.LocalPortHigh == DefaultConfig.LocalPortHigh {
-		s.LocalPortHigh = 0
 	}
 
 	return &s
@@ -195,6 +195,12 @@ func (c *Config) commonBackfill(configMap map[string]interface{}) *Config {
 	if _, exists := configMap["cups_printer_poll_interval"]; !exists {
 		b.NativePrinterPollInterval = DefaultConfig.NativePrinterPollInterval
 	}
+	if _, exists := configMap["cups_job_full_username"]; !exists {
+		b.CUPSJobFullUsername = DefaultConfig.CUPSJobFullUsername
+	}
+	if _, exists := configMap["job_spooled_is_done"]; !exists {
+		b.JobSpooledIsDone = DefaultConfig.JobSpooledIsDone
+	}
 	if _, exists := configMap["prefix_job_id_to_job_title"]; !exists {
 		b.PrefixJobIDToJobTitle = DefaultConfig.PrefixJobIDToJobTitle
 	}
@@ -212,12 +218,6 @@ func (c *Config) commonBackfill(configMap map[string]interface{}) *Config {
 	}
 	if _, exists := configMap["log_level"]; !exists {
 		b.LogLevel = DefaultConfig.LogLevel
-	}
-	if _, exists := configMap["local_port_low"]; !exists {
-		b.LocalPortLow = DefaultConfig.LocalPortLow
-	}
-	if _, exists := configMap["local_port_high"]; !exists {
-		b.LocalPortHigh = DefaultConfig.LocalPortHigh
 	}
 
 	return &b

--- a/lib/config_unix.go
+++ b/lib/config_unix.go
@@ -86,6 +86,10 @@ type Config struct {
 	// TODO: rename without cups_ prefix
 	NativePrinterPollInterval string `json:"cups_printer_poll_interval,omitempty"`
 
+	// Use the full username (joe@example.com) in job.
+	// TODO: rename without cups_ prefix
+	CUPSJobFullUsername *bool `json:"cups_job_full_username,omitempty"`
+
 	// Add the job ID to the beginning of the job title. Useful for debugging.
 	PrefixJobIDToJobTitle *bool `json:"prefix_job_id_to_job_title,omitempty"`
 
@@ -97,12 +101,6 @@ type Config struct {
 
 	// Least severity to log.
 	LogLevel string `json:"log_level"`
-
-	// Local only: HTTP API port range, low.
-	LocalPortLow uint16 `json:"local_port_low,omitempty"`
-
-	// Local only: HTTP API port range, high.
-	LocalPortHigh uint16 `json:"local_port_high,omitempty"`
 
 	// CUPS only: Where to place log file.
 	LogFileName string `json:"log_file_name"`
@@ -127,9 +125,6 @@ type Config struct {
 
 	// CUPS only: printer attributes to copy to GCP.
 	CUPSPrinterAttributes []string `json:"cups_printer_attributes,omitempty"`
-
-	// CUPS only: use the full username (joe@example.com) in CUPS job.
-	CUPSJobFullUsername *bool `json:"cups_job_full_username,omitempty"`
 
 	// CUPS only: ignore printers with make/model 'Local Raw Printer'.
 	CUPSIgnoreRawPrinters *bool `json:"cups_ignore_raw_printers,omitempty"`
@@ -166,9 +161,6 @@ var DefaultConfig = Config{
 	DisplayNamePrefix:         "",
 	PrinterBlacklist:          []string{},
 	LogLevel:                  "INFO",
-
-	LocalPortLow:  26000,
-	LocalPortHigh: 26999,
 
 	LogFileName:         "/tmp/cups-connector",
 	LogFileMaxMegabytes: 1,

--- a/lib/config_windows.go
+++ b/lib/config_windows.go
@@ -84,6 +84,15 @@ type Config struct {
 	// TODO: rename without cups_ prefix
 	NativePrinterPollInterval string `json:"cups_printer_poll_interval,omitempty"`
 
+	// Use the full username (joe@example.com) in job.
+	// TODO: rename without cups_ prefix
+	CUPSJobFullUsername *bool `json:"cups_job_full_username,omitempty"`
+
+	// When the job finishes spooling, mark it as done.
+	// This is for compatibility with other products that pause jobs to process them.
+	// TODO: this is only in the Windows build for now - decide whether useful in Unix
+	JobSpooledIsDone *bool `json:"job_spooled_is_done,omitempty"`
+
 	// Add the job ID to the beginning of the job title. Useful for debugging.
 	PrefixJobIDToJobTitle *bool `json:"prefix_job_id_to_job_title,omitempty"`
 
@@ -95,12 +104,6 @@ type Config struct {
 
 	// Least severity to log.
 	LogLevel string `json:"log_level"`
-
-	// Local only: HTTP API port range, low.
-	LocalPortLow uint16 `json:"local_port_low,omitempty"`
-
-	// Local only: HTTP API port range, high.
-	LocalPortHigh uint16 `json:"local_port_high,omitempty"`
 }
 
 // DefaultConfig represents reasonable default values for Config fields.
@@ -120,6 +123,8 @@ var DefaultConfig = Config{
 
 	NativeJobQueueSize:        3,
 	NativePrinterPollInterval: "1m",
+	CUPSJobFullUsername:       PointerToBool(false),
+	JobSpooledIsDone:          PointerToBool(false),
 	PrefixJobIDToJobTitle:     PointerToBool(false),
 	DisplayNamePrefix:         "",
 	PrinterBlacklist: []string{
@@ -131,9 +136,6 @@ var DefaultConfig = Config{
 	LocalPrintingEnable: true,
 	CloudPrintingEnable: false,
 	LogLevel:            "INFO",
-
-	LocalPortLow:  26000,
-	LocalPortHigh: 26999,
 }
 
 // getConfigFilename gets the absolute filename of the config file specified by

--- a/winspool/win32.go
+++ b/winspool/win32.go
@@ -573,8 +573,8 @@ func enumPrinters(level uint32) ([]byte, uint32, error) {
 	}
 
 	var pPrinterEnum []byte = make([]byte, cbBuf)
-	_, _, err = enumPrintersProc.Call(PRINTER_ENUM_LOCAL, 0, uintptr(level), uintptr(unsafe.Pointer(&pPrinterEnum[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)), uintptr(unsafe.Pointer(&pcReturned)))
-	if err != NO_ERROR {
+	r1, _, err := enumPrintersProc.Call(PRINTER_ENUM_LOCAL, 0, uintptr(level), uintptr(unsafe.Pointer(&pPrinterEnum[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)), uintptr(unsafe.Pointer(&pcReturned)))
+	if r1 == 0 {
 		return nil, 0, err
 	}
 
@@ -606,16 +606,16 @@ func OpenPrinter(printerName string) (HANDLE, error) {
 	}
 
 	var hPrinter HANDLE
-	_, _, err = openPrinterProc.Call(uintptr(unsafe.Pointer(pPrinterName)), uintptr(unsafe.Pointer(&hPrinter)), 0)
-	if err != NO_ERROR {
+	r1, _, err := openPrinterProc.Call(uintptr(unsafe.Pointer(pPrinterName)), uintptr(unsafe.Pointer(&hPrinter)), 0)
+	if r1 == 0 {
 		return 0, err
 	}
 	return hPrinter, nil
 }
 
 func (hPrinter *HANDLE) ClosePrinter() error {
-	_, _, err := closePrinterProc.Call(uintptr(*hPrinter))
-	if err != NO_ERROR {
+	r1, _, err := closePrinterProc.Call(uintptr(*hPrinter))
+	if r1 == 0 {
 		return err
 	}
 	*hPrinter = 0
@@ -726,8 +726,8 @@ func (hPrinter HANDLE) GetJob(jobID int32) (*JobInfo1, error) {
 	}
 
 	var pJob []byte = make([]byte, cbBuf)
-	_, _, err = getJobProc.Call(uintptr(hPrinter), uintptr(jobID), 1, uintptr(unsafe.Pointer(&pJob[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)))
-	if err != NO_ERROR {
+	r1, _, err := getJobProc.Call(uintptr(hPrinter), uintptr(jobID), 1, uintptr(unsafe.Pointer(&pJob[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)))
+	if r1 == 0 {
 		return nil, err
 	}
 
@@ -749,12 +749,39 @@ const (
 	JOB_CONTROL_RELEASE           uint32 = 9
 )
 
-func (hPrinter HANDLE) SetJob(jobID int32, command uint32) error {
-	_, _, err := setJobProc.Call(uintptr(hPrinter), uintptr(jobID), 0, 0, uintptr(command))
-	if err != NO_ERROR {
+func (hPrinter HANDLE) SetJobCommand(jobID int32, command uint32) error {
+	r1, _, err := setJobProc.Call(uintptr(hPrinter), uintptr(jobID), 0, 0, uintptr(command))
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+func (hPrinter HANDLE) SetJob1(jobID int32, ji1 *JobInfo1) error {
+	r1, _, err := setJobProc.Call(uintptr(hPrinter), uintptr(jobID), 1, uintptr(unsafe.Pointer(ji1)), 0)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+func (hPrinter HANDLE) SetJobUserName(jobID int32, userName string) error {
+	ji1, err := hPrinter.GetJob(jobID)
+	if err != nil {
 		return err
 	}
 
+	pUserName, err := syscall.UTF16PtrFromString(userName)
+	if err != nil {
+		return err
+	}
+
+	ji1.pUserName = pUserName;
+	ji1.position = 0; // To prevent a possible access denied error (0 is JOB_POSITION_UNSPECIFIED)
+	err = hPrinter.SetJob1(jobID, ji1)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -769,7 +796,6 @@ func CreateDC(deviceName string, devMode *DevMode) (HDC, error) {
 	if r1 == 0 {
 		return 0, err
 	}
-
 	return HDC(r1), nil
 }
 
@@ -806,15 +832,15 @@ func (hDC HDC) StartDoc(docName string) (int32, error) {
 	}
 
 	r1, _, err := startDocProc.Call(uintptr(hDC), uintptr(unsafe.Pointer(&docInfo)))
-	if err != NO_ERROR {
+	if r1 <= 0 {
 		return 0, err
 	}
 	return int32(r1), nil
 }
 
 func (hDC HDC) EndDoc() error {
-	_, _, err := endDocProc.Call(uintptr(hDC))
-	if err != NO_ERROR {
+	r1, _, err := endDocProc.Call(uintptr(hDC))
+	if r1 <= 0 {
 		return err
 	}
 	return nil
@@ -827,16 +853,16 @@ func (hDC HDC) AbortDoc() error {
 }
 
 func (hDC HDC) StartPage() error {
-	_, _, err := startPageProc.Call(uintptr(hDC))
-	if err != NO_ERROR {
+	r1, _, err := startPageProc.Call(uintptr(hDC))
+	if r1 <= 0 {
 		return err
 	}
 	return nil
 }
 
 func (hDC HDC) EndPage() error {
-	_, _, err := endPageProc.Call(uintptr(hDC))
-	if err != NO_ERROR {
+	r1, _, err := endPageProc.Call(uintptr(hDC))
+	if r1 <= 0 {
 		return err
 	}
 	return nil
@@ -848,8 +874,8 @@ const (
 )
 
 func (hDC HDC) SetGraphicsMode(iMode int32) error {
-	_, _, err := setGraphicsModeProc.Call(uintptr(hDC), uintptr(iMode))
-	if err != NO_ERROR {
+	r1, _, err := setGraphicsModeProc.Call(uintptr(hDC), uintptr(iMode))
+	if r1 == 0 {
 		return err
 	}
 	return nil


### PR DESCRIPTION
I've just submitted the CLA. Apologies it's all one big commit.

- Implemented cups_job_full_username option in Windows port
- Added job_spooled_is_done option and implemented in Windows port
- Renamed old SetJob to SetJobCommand since it only uses commands
- Added SetJobUserName which is used to change the username
- Corrected error handling for: EnumPrinters, OpenPrinter, ClosePrinter, GetJob, SetJob, StartDoc, EndDoc, StartPage, EndPage, SetGraphicsMode

Notes
- The job_spooled_is_done feature is for software (like ours) which pauses the job and takes over the release process. You may want to rename the option.
- Without global config, passing new options to depth is a bit painful. It would be easier to pass around a collection.
- I have not added boilerplate "err == NO_ERROR" checks everywhere (for "The operation completed successfully" errors). Those Windows bugs are pretty rare.