### PR TITLE
Implemented cups_job_full_username option in Windows port (and more)

### DIFF
--- a/cups/cups.go
+++ b/cups/cups.go
@@ -399,7 +399,7 @@ func (c *CUPS) RemoveCachedPPD(printername string) {
 }
 
 // GetJobState gets the current state of the job indicated by jobID.
-func (c *CUPS) GetJobState(_ string, jobID uint32) (*cdd.PrintJobStateDiff, error) {
+func (c *CUPS) GetJobState(_ string, jobID uint32, jobSpooledIsDone bool) (*cdd.PrintJobStateDiff, error) {
 	ja := C.newArrayOfStrings(C.int(len(jobAttributes)))
 	defer C.freeStringArrayAndStrings(ja, C.int(len(jobAttributes)))
 	for i, attribute := range jobAttributes {

--- a/gcp-connector-util/main_windows.go
+++ b/gcp-connector-util/main_windows.go
@@ -221,6 +221,8 @@ func createCloudConfig(context *cli.Context, xmppJID, robotRefreshToken, userRef
 
 		NativeJobQueueSize:        uint(context.Int("native-job-queue-size")),
 		NativePrinterPollInterval: context.String("native-printer-poll-interval"),
+		CUPSJobFullUsername:       lib.PointerToBool(context.Bool("cups-job-full-username")),
+		JobSpooledIsDone:          lib.PointerToBool(context.Bool("job-spooled-is-done")),
 		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,
@@ -239,6 +241,8 @@ func createLocalConfig(context *cli.Context) *lib.Config {
 
 		NativeJobQueueSize:        uint(context.Int("native-job-queue-size")),
 		NativePrinterPollInterval: context.String("native-printer-poll-interval"),
+		CUPSJobFullUsername:       lib.PointerToBool(context.Bool("cups-job-full-username")),
+		JobSpooledIsDone:          lib.PointerToBool(context.Bool("job-spooled-is-done")),
 		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,

--- a/gcp-cups-connector/gcp-cups-connector.go
+++ b/gcp-cups-connector/gcp-cups-connector.go
@@ -184,7 +184,7 @@ func connector(context *cli.Context) int {
 		return 1
 	}
 	pm, err := manager.NewPrinterManager(c, g, priv, nativePrinterPollInterval,
-		config.NativeJobQueueSize, *config.CUPSJobFullUsername, config.ShareScope,
+		config.NativeJobQueueSize, *config.CUPSJobFullUsername, false, config.ShareScope,
 		jobs, xmppNotifications)
 	if err != nil {
 		log.Fatal(err)

--- a/gcp-cups-driver/README.md
+++ b/gcp-cups-driver/README.md
@@ -1,0 +1,12 @@
+This driver is experimental.
+
+Copy backend-local to /usr/libexec/cups/backend/gcp-local
+
+To build the PPD files:
+
+```
+ppdc driver.drv
+```
+
+Copy driver.drv (not the PPDs) to /usr/share/cups/drv. This doesn't work currently due to SIP:
+https://en.wikipedia.org/wiki/System_Integrity_Protection

--- a/gcp-cups-driver/backend-common/cupsfilterlog.go
+++ b/gcp-cups-driver/backend-common/cupsfilterlog.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file or at
+https://developers.google.com/open-source/licenses/bsd
+*/
+
+// The functions in cupsfilterlog write log message to STDERR, per CUPS filter(7) manpage:
+// https://www.cups.org/documentation.php/man-filter.html
+package common
+
+import (
+	"fmt"
+	"os"
+)
+
+// logPrefix is a single word that appears at the first line of a log entry,
+// as described in the filter(7) manpage.
+type logPrefix string
+
+const (
+	PrefixAttr  logPrefix = "ATTR"
+	PrefixPage  logPrefix = "PAGE"
+	PrefixPPD   logPrefix = "PPD"
+	PrefixState logPrefix = "STATE"
+)
+
+func Logf(prefix logPrefix, format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "%s: %s", prefix, fmt.Sprintf(format, args...))
+}
+
+// LogLevel represents the severity of a log message.
+type LogLevel logPrefix
+
+const (
+	LevelEmerg   LogLevel = "EMERG"
+	LevelAlert   LogLevel = "ALERT"
+	LevelCrit    LogLevel = "CRIT"
+	LevelError   LogLevel = "ERROR"
+	LevelWarning LogLevel = "WARNING"
+	LevelNotice  LogLevel = "NOTICE"
+	LevelInfo    LogLevel = "INFO"
+	LevelDebug   LogLevel = "DEBUG"
+	LevelDebug2  LogLevel = "DEBUG2"
+)
+
+func Alert(format string, args ...interface{})   { Logf(logPrefix(LevelAlert), format, args...) }
+func Crit(format string, args ...interface{})    { Logf(logPrefix(LevelCrit), format, args...) }
+func Debug(format string, args ...interface{})   { Logf(logPrefix(LevelDebug), format, args...) }
+func Debug2(format string, args ...interface{})  { Logf(logPrefix(LevelDebug2), format, args...) }
+func Emerg(format string, args ...interface{})   { Logf(logPrefix(LevelEmerg), format, args...) }
+func Error(format string, args ...interface{})   { Logf(logPrefix(LevelError), format, args...) }
+func Info(format string, args ...interface{})    { Logf(logPrefix(LevelInfo), format, args...) }
+func Notice(format string, args ...interface{})  { Logf(logPrefix(LevelNotice), format, args...) }
+func Warning(format string, args ...interface{}) { Logf(logPrefix(LevelWarning), format, args...) }
+
+// StateLevel represents the severity suffix described in RFC 2911 section 4.4.12.
+type StateLevel logPrefix
+
+const (
+	StateReport  StateLevel = "report"
+	StateWarning StateLevel = "warning"
+	StateError   StateLevel = "error"
+)
+
+func AddStateReason(state StateLevel, reason string)    { Logf(PrefixState, "+%s-%s", reason, state) }
+func RemoveStateReason(state StateLevel, reason string) { Logf(PrefixState, "-%s-%s", reason, state) }
+
+func SetPPDKeywordValue(keyword string, value string) { Logf(PrefixPPD, "%s=%s", keyword, value) }

--- a/gcp-cups-driver/backend-common/env.go
+++ b/gcp-cups-driver/backend-common/env.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file or at
+https://developers.google.com/open-source/licenses/bsd
+*/
+
+package common
+
+import "os"
+
+func Env(name string) (string, bool) {
+	deviceURI := os.Getenv(name)
+	if deviceURI == "" {
+		Crit("%s env variable is not set", name)
+		return "", false
+	}
+	return deviceURI, true
+}

--- a/gcp-cups-driver/backend-local/backend-local.go
+++ b/gcp-cups-driver/backend-local/backend-local.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file or at
+https://developers.google.com/open-source/licenses/bsd
+*/
+
+// Google Cloud Print CUPS Virtual Driver, backend
+//
+// Implements a CUPS backend as described here:
+// https://www.cups.org/documentation.php/man-backend.html
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/google/cups-connector/cdd"
+	"github.com/google/cups-connector/gcp-cups-driver/backend-common"
+)
+
+const (
+	schema        = "gcp-local"
+	backendFormat = `network gcp-local://%s "%s" "%s" "%s"`
+	ieee1284PDF   = "MANUFACTURER:Google;MODEL:Cloud Print - PDF;SERIALNUMBER:%s"
+	ieee1284PWG   = "MANUFACTURER:Google;MODEL:Cloud Print - PWG;SERIALNUMBER:%s"
+)
+
+type printer struct {
+	name         string
+	info         *privetInfo
+	capabilities *cdd.CloudDeviceDescription
+}
+
+func main() {
+	switch len(os.Args) {
+	case 1:
+		if !discover() {
+			break
+		}
+		return
+
+	case 6, 7:
+		var f *os.File
+		var err error
+		if len(os.Args) == 7 {
+			// Read file at filename. Assume the caller will delete the file.
+			f, err = os.Open(os.Args[6])
+			if err != nil {
+				common.Error("Failed to open job payload file %s: %s", os.Args[6], err)
+				break
+			}
+			defer f.Close()
+
+		} else {
+			f, ok := stdinToFile()
+			if !ok {
+				break
+			}
+			defer func() {
+				f.Close()
+				os.Remove(f.Name())
+			}()
+		}
+		ok := printJob(os.Args[1], os.Args[2], os.Args[3], os.Args[4], os.Args[5], f)
+		if ok {
+			return
+		}
+
+	default:
+		common.Info("Usage: %s job-id user title copies options [filename]", os.Args[0])
+	}
+
+	os.Exit(1)
+}
+
+// stdinToFile copies the contents of os.Stdin to a temporary file. This is necessary
+// to get the size of the incoming job for the Content-Length HTTP request header.
+// Returns the file object and true, or nil and false on failure.
+func stdinToFile() (*os.File, bool) {
+	tmpDir, ok := common.Env("TMPDIR")
+	if !ok {
+		return nil, false
+	}
+
+	f, err := ioutil.TempFile(tmpDir, "gcp-local-job")
+	if err != nil {
+		common.Error("Failed to create a temporary file to copy STDIN contents to: %s, err")
+		return nil, false
+	}
+	contentLength, err := io.Copy(f, os.Stdin)
+	if err != nil {
+		common.Error("Failed to copy STDIN contents to %s", f.Name())
+		f.Close()
+		os.Remove(f.Name())
+		return nil, false
+	}
+	if contentLength == 0 {
+		common.Error("Cannot print empty payload")
+		f.Close()
+		os.Remove(f.Name())
+		return nil, false
+	}
+
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		common.Error("Failed to seek to start of new temporary file %s: %s", f.Name(), err)
+		f.Close()
+		os.Remove(f.Name())
+		return nil, false
+	}
+
+	return f, true
+}
+
+// discover finds all Privet printers via DNS-SD.
+// Returns true on success, false on failure.
+func discover() bool {
+	var wg sync.WaitGroup
+	fmt.Println(`network gcp-local "Unknown" "Google Cloud Print (local)"`)
+
+	for d, i := discoverPrinters(), 0; i < len(d); i++ {
+		wg.Add(1)
+		go func(d *dnssdService) {
+			defer wg.Done()
+
+			pc := newPrivetClient(d.hostname, d.port)
+			info := pc.info()
+			if info == nil {
+				return
+			}
+
+			capabilities, ok := pc.capabilities()
+			if !ok {
+				return
+			}
+
+			var serialNumber string
+			if info.SerialNumber != "" {
+				serialNumber = info.SerialNumber
+			} else {
+				serialNumber = d.name
+			}
+
+			var deviceID string
+			if capabilities.supportsPDF() {
+				deviceID = fmt.Sprintf(ieee1284PDF, serialNumber)
+			} else {
+				deviceID = fmt.Sprintf(ieee1284PWG, serialNumber)
+			}
+
+			fmt.Println(fmt.Sprintf(backendFormat, d.name, info.deviceMakeAndModel(), info.Name, deviceID))
+		}(&d[i])
+	}
+
+	wg.Wait()
+	return true
+}
+
+func printJob(id, user, title, copies, options string, f *os.File) bool {
+	deviceURI, ok := common.Env("DEVICE_URI")
+	if !ok {
+		return false
+	}
+
+	contentType, ok := common.Env("CONTENT_TYPE")
+	if !ok {
+		return false
+	}
+
+	printerName := strings.TrimPrefix(deviceURI, "gcp-local://")
+	service, ok := resolvePrinter(printerName)
+	if !ok {
+		return false
+	}
+	pc := newPrivetClient(service.hostname, service.port)
+
+	info := pc.info()
+	if info == nil {
+		return false
+	}
+
+	// TODO: Options to CJT; call pc.createJob.
+
+	jobID, ok := pc.submitDoc("", user, title, f, contentType)
+	if !ok {
+		return false
+	}
+	common.Info("Done printing %s", jobID)
+	return true
+}

--- a/gcp-cups-driver/backend-local/dnssd.c
+++ b/gcp-cups-driver/backend-local/dnssd.c
@@ -1,0 +1,118 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file or at
+https://developers.google.com/open-source/licenses/bsd
+*/
+
+#include "dnssd.h"
+
+const char *SERVICE_TYPE = "_privet._tcp";
+
+void resolveCallback(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t interfaceIndex, DNSServiceErrorType errorCode, const char *fullname, const char *hostname, uint16_t port, uint16_t txtLen, const unsigned char *txtRecord, void *context) {
+	if (errorCode != kDNSServiceErr_NoError) {
+		logError("DNS-SD failed to resolve (in callback); errorCode = %d", errorCode);
+		return;
+	}
+	struct service_s *service = context;
+	service->hostname = strdup(hostname);
+	service->port = ntohs(port);
+}
+
+void discoverPrintersBrowseCallback(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t interfaceIndex, DNSServiceErrorType errorCode, const char *name, const char *serviceType, const char *domain, void *context) {
+	if (errorCode != kDNSServiceErr_NoError) {
+		logError("DNS-SD failed to browse (in callback); errorCode = %d", errorCode);
+		return;
+	}
+	struct service_s *service = calloc(1, sizeof(struct service_s));
+	service->hostname = NULL;
+
+	DNSServiceErrorType error = DNSServiceResolve(&sdRef, 0, interfaceIndex, name, SERVICE_TYPE, domain, resolveCallback, service);
+	if (error != kDNSServiceErr_NoError) {
+		free(service);
+		logError("DNS-SD failed to resolve %s; error = %d", name, error);
+		return;
+	}
+	DNSServiceProcessResult(sdRef);
+
+	if (service->hostname == NULL) {
+		free(service);
+		logError("DNS-SD got a null hostname");
+		return;
+	}
+
+	service->name = strdup(name);
+
+	struct service_list_s **services = context;
+	while (*services != NULL) {
+		services = &((*services)->next);
+	}
+	*services = calloc(1, sizeof(struct service_list_s));
+	(*services)->service = service;
+}
+
+struct service_list_s *discoverPrinters() {
+	struct service_list_s *services = NULL;
+
+	DNSServiceRef sdRef;
+	DNSServiceErrorType error = DNSServiceBrowse(&sdRef, 0, 0, SERVICE_TYPE, NULL, discoverPrintersBrowseCallback, (void *) &services);
+	if (error != kDNSServiceErr_NoError) {
+		logError("DNS-SD failed to browse services; error = %d", error);
+		return NULL;
+	}
+
+	int dnssd_fd = DNSServiceRefSockFD(sdRef);
+	int nfds = dnssd_fd + 1;
+	fd_set readfds;
+	FD_ZERO(&readfds);
+	FD_SET(dnssd_fd, &readfds);
+	struct timeval timeout = {1, 0}; // One second.
+	int result = select(nfds, &readfds, NULL, NULL, &timeout);
+	if (result > 0) {
+		// Process result if results exist; this blocks if no results.
+		DNSServiceProcessResult(sdRef);
+	} else if (result < 0) {
+		logError("System error occurred while select()ing: %s", strerror(errno));
+	}
+
+	DNSServiceRefDeallocate(sdRef);
+
+	return services;
+}
+
+void resolvePrinterBrowseCallback(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t interfaceIndex, DNSServiceErrorType errorCode, const char *name, const char *serviceType, const char *domain, void *context) {
+	if (errorCode != kDNSServiceErr_NoError) {
+		logError("DNS-SD failed to browse (in callback); errorCode = %d", errorCode);
+		return;
+	}
+
+	struct service_s *service = context;
+	if (strcmp(name, service->name)) {
+		return;
+	}
+
+	DNSServiceErrorType error = DNSServiceResolve(&sdRef, 0, interfaceIndex, name, SERVICE_TYPE, domain, resolveCallback, service);
+	if (error != kDNSServiceErr_NoError) {
+		logError("DNS-SD failed to resolve %s; error = %d", name, error);
+		return;
+	}
+	DNSServiceProcessResult(sdRef);
+}
+
+struct service_s *resolvePrinter(const char *name) {
+	struct service_s *service = calloc(1, sizeof(struct service_s));
+	service->name = (char *)name;
+
+	DNSServiceRef sdRef;
+	DNSServiceErrorType error = DNSServiceBrowse(&sdRef, 0, 0, SERVICE_TYPE, NULL, resolvePrinterBrowseCallback, (void *) service);
+	if (error != kDNSServiceErr_NoError) {
+		logError("DNS-SD failed to resolve %s; error = %d", name, error);
+		return NULL;
+	}
+	DNSServiceProcessResult(sdRef);
+	DNSServiceRefDeallocate(sdRef);
+
+	service->name = NULL;
+	return service;
+}

--- a/gcp-cups-driver/backend-local/dnssd.go
+++ b/gcp-cups-driver/backend-local/dnssd.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file or at
+https://developers.google.com/open-source/licenses/bsd
+*/
+
+package main
+
+/*
+#include "dnssd.h"
+*/
+import "C"
+import "unsafe"
+
+type dnssdService struct {
+	name     string
+	hostname string
+	port     uint16
+}
+
+// discoverPrinters discovers all Privet printers via DNS-SD.
+func discoverPrinters() []dnssdService {
+	var services []dnssdService
+
+	for dp := C.discoverPrinters(); dp != nil; dp = dp.next {
+		service := dnssdService{
+			C.GoString(dp.service.name),
+			C.GoString(dp.service.hostname),
+			uint16(dp.service.port),
+		}
+		services = append(services, service)
+
+		defer C.free(unsafe.Pointer(dp.service.name))
+		defer C.free(unsafe.Pointer(dp.service.hostname))
+		defer C.free(unsafe.Pointer(dp.service))
+		defer C.free(unsafe.Pointer(dp))
+	}
+
+	return services
+}
+
+// resolvePrinter resolves a printer name so we know it's hostname:port.
+// The second return value is false when the printer can't be resolved.
+func resolvePrinter(name string) (dnssdService, bool) {
+	nameC := C.CString(name)
+	defer C.free(unsafe.Pointer(nameC))
+
+	rp := C.resolvePrinter(nameC)
+	if rp == nil {
+		return dnssdService{}, false
+	}
+	defer C.free(unsafe.Pointer(rp))
+
+	if rp.hostname != nil {
+		hostname := C.GoString(rp.hostname)
+		C.free(unsafe.Pointer(rp.hostname))
+		port := uint16(rp.port)
+		return dnssdService{name, hostname, port}, true
+	}
+
+	return dnssdService{}, false
+}

--- a/gcp-cups-driver/backend-local/dnssd.h
+++ b/gcp-cups-driver/backend-local/dnssd.h
@@ -1,0 +1,31 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file or at
+https://developers.google.com/open-source/licenses/bsd
+*/
+
+#include <dns_sd.h>
+#include "dnssd_log.h"
+
+#include <arpa/inet.h>  // ntohs
+#include <errno.h>      // errno
+#include <stdlib.h>     // calloc, free
+#include <string.h>     // strcmp, strdup
+#include <sys/select.h> // select
+#include <sys/time.h>   // timeval
+
+struct service_s {
+	char     *name;
+	char     *hostname;
+	uint16_t port;
+};
+
+struct service_list_s {
+	struct service_s      *service;
+	struct service_list_s *next;
+};
+
+struct service_list_s *discoverPrinters();
+struct service_s *resolvePrinter(const char *name);

--- a/gcp-cups-driver/backend-local/dnssd_log.c
+++ b/gcp-cups-driver/backend-local/dnssd_log.c
@@ -1,0 +1,39 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file or at
+https://developers.google.com/open-source/licenses/bsd
+*/
+
+#include "dnssd_log.h"
+
+const char *LEVEL_EMERG = "EMERG",
+			*LEVEL_ALERT      = "ALERT",
+			*LEVEL_CRIT      	= "CRIT",
+			*LEVEL_ERROR      = "ERROR",
+			*LEVEL_WARNING    = "WARNING",
+			*LEVEL_NOTICE     = "NOTICE",
+			*LEVEL_INFO       = "INFO",
+			*LEVEL_DEBUG      = "DEBUG",
+			*LEVEL_DEBUG2     = "DEBUG2";
+
+void logLevel(const char *level, const char *format, va_list args) {
+	char *new_format = NULL;
+	int err = asprintf(&new_format, "%s: %s\n", level, format);
+	if (err < 0) {
+		fprintf(stderr, "%s: The function asprintf() failed to malloc", LEVEL_CRIT);
+		return;
+	}
+
+	vfprintf(stderr, new_format, args);
+
+	free(new_format);
+}
+
+void logError(const char *format, ...) {
+	va_list args;
+	va_start(args, format);
+	logLevel(LEVEL_ERROR, format, args);
+	va_end(args);
+}

--- a/gcp-cups-driver/backend-local/dnssd_log.h
+++ b/gcp-cups-driver/backend-local/dnssd_log.h
@@ -1,0 +1,14 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file or at
+https://developers.google.com/open-source/licenses/bsd
+*/
+
+#include <stdarg.h> // vfprintf
+#include <stdio.h>  // stderr, asprintf
+#include <stdlib.h> // free
+#include <string.h> // strcat, strlen
+
+void logError(const char *format, ...);

--- a/gcp-cups-driver/backend-local/http.go
+++ b/gcp-cups-driver/backend-local/http.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file or at
+https://developers.google.com/open-source/licenses/bsd
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/google/cups-connector/cdd"
+	"github.com/google/cups-connector/gcp-cups-driver/backend-common"
+)
+
+type privetInfo struct {
+	Version         string                `json:"version"`
+	Name            string                `json:"name"`
+	Description     string                `json:"description"`
+	URL             string                `json:"url"`
+	Type            []string              `json:"type"`
+	ID              string                `json:"id"`
+	DeviceState     string                `json:"device_state"`
+	ConnectionState string                `json:"connection_state"`
+	Manufacturer    string                `json:"manufacturer"`
+	Model           string                `json:"model"`
+	SerialNumber    string                `json:"serial_number"`
+	Firmware        string                `json:"firmware"`
+	Uptime          int                   `json:"uptime"`
+	SetupURL        string                `json:"setup_url"`
+	SupportURL      string                `json:"support_url"`
+	UpdateURL       string                `json:"update_url"`
+	XPrivetToken    string                `json:"x-privet-token"`
+	API             []string              `json:"api"`
+	SemanticState   *cdd.CloudDeviceState `json:"semantic_state"`
+}
+
+func stringSliceContains(needle string, haystack []string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func (pi *privetInfo) deviceMakeAndModel() string {
+	if pi.Manufacturer == "" {
+		if pi.Model == "" {
+			return ""
+		} else {
+			return pi.Model
+		}
+	} else {
+		if pi.Model == "" {
+			return pi.Manufacturer
+		} else {
+			return fmt.Sprintf("%s %s", pi.Manufacturer, pi.Model)
+		}
+	}
+}
+
+// privetClient is the interface with a Privet printer.
+type privetClient struct {
+	host string
+	// info is useful for reference internally, so we keep a reference to the most
+	// recent copy.
+	latestInfo *privetInfo
+}
+
+func newPrivetClient(hostname string, port uint16) *privetClient {
+	return &privetClient{
+		host: fmt.Sprintf("%s:%d", hostname, port),
+	}
+}
+
+type privetError struct {
+	Error          *string `json:"error,omitempty"`
+	Description    *string `json:"description,omitempty"`
+	ServerAPI      *string `json:"server_api,omitempty"`
+	ServerCode     *int32  `json:"server_code,omitempty"`
+	ServerHTTPCode *int32  `json:"server_http_code,omitempty"`
+	Timeout        *int32  `json:"timeout,omitempty"`
+}
+
+func (pe *privetError) string() string {
+	if pe.Error == nil {
+		return ""
+	}
+	var s string
+	s += *pe.Error
+	if pe.Description != nil {
+		s += " description: " + *pe.Description
+	}
+	if pe.ServerAPI != nil {
+		s += " server API: " + *pe.ServerAPI
+	}
+	if pe.ServerCode != nil {
+		s += " server code: " + string(*pe.ServerCode)
+	}
+	if pe.ServerHTTPCode != nil {
+		s += " server HTTP code: " + string(*pe.ServerHTTPCode)
+	}
+	if pe.Timeout != nil {
+		s += " timeout: " + string(*pe.Timeout)
+	}
+	return s
+}
+
+// doHTTPRequest calls path arg with method arg. Returns a privetError if the response contains an error.
+func (pc *privetClient) doHTTPRequest(method, path string, form url.Values, body *os.File, contentType string) ([]byte, *privetError, error) {
+	var token string
+	if pc.latestInfo != nil {
+		token = pc.latestInfo.XPrivetToken
+	}
+
+	req := http.Request{
+		Method: method,
+		URL: &url.URL{
+			Scheme: "http",
+			Host:   pc.host,
+			Path:   path,
+		},
+		Header: map[string][]string{"X-Privet-Token": {token}},
+		Form:   form,
+	}
+
+	if body != nil {
+		fi, err := body.Stat()
+		if err != nil {
+			return []byte{}, nil, fmt.Errorf("Failed to stat print job file: %s", err)
+		}
+
+		req.Header["Content-Type"] = []string{contentType}
+		req.ContentLength = fi.Size()
+		req.Body = body
+		req.Close = false
+	}
+
+	res, err := http.DefaultClient.Do(&req)
+	if err != nil {
+		return []byte{}, nil, fmt.Errorf("HTTP request failed: %s", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return []byte{}, nil, fmt.Errorf("HTTP response status code %d", res.StatusCode)
+	}
+
+	responseBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return []byte{}, nil, fmt.Errorf("HTTP response body could not be read: %s", err)
+	}
+
+	var pe privetError
+	if err = json.Unmarshal(responseBody, &pe); err != nil {
+		return []byte{}, nil, errors.New("Failed to unmarshal JSON")
+	}
+	if pe.Error != nil {
+		return responseBody, &pe, nil
+	}
+
+	return responseBody, nil, nil
+}
+
+// info calls /privet/info and updates the internal X-Privet-Token value implicitly.
+// Returns nil on failure.
+func (pc *privetClient) info() *privetInfo {
+	body, pe, err := pc.doHTTPRequest("GET", "/privet/info", nil, nil, "")
+	if err != nil {
+		common.Error("Failed to get printer info: %s", err)
+		return nil
+	}
+	if pe != nil {
+		common.Error("Printer returned an error: %s", pe.string())
+		return nil
+	}
+
+	var info privetInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		common.Error("Failed to unmarshal JSON: %s", err)
+		return nil
+	}
+
+	pc.latestInfo = &info
+
+	return &info
+}
+
+// capabilities returns the capabilities of the printer, and true on success.
+// The capabilities API is optional, so (nil, true) is returned if the printer
+// doesn't support it.
+func (pc *privetClient) capabilities() (*CloudDeviceDescription, bool) {
+	if !pc.supportsCapabilities() {
+		return nil, true
+	}
+
+	body, pe, err := pc.doHTTPRequest("GET", "/privet/capabilities", nil, nil, "")
+	if err != nil {
+		common.Error("Failed to get printer capabilities: %s", err)
+		return nil, false
+	}
+	if pe != nil {
+		common.Error("Printer returned an error: %s", pe.string())
+		return nil, false
+	}
+
+	var capabilities CloudDeviceDescription
+	if err = json.Unmarshal(body, &capabilities); err != nil {
+		common.Error("Failed to unmarshal JSON: %s", err)
+		return nil, false
+	}
+	return &capabilities, true
+}
+
+func (pc *privetClient) supportsCapabilities() bool {
+	if pc.latestInfo == nil {
+		common.Error("Cannot acquire printer capabilities without info() call first")
+		return false
+	}
+	return stringSliceContains("/privet/capabilities", pc.latestInfo.API)
+}
+
+type CloudDeviceDescription struct {
+	*cdd.CloudDeviceDescription
+}
+
+func (c *CloudDeviceDescription) supportsPDF() bool {
+	if c != nil && c.Printer != nil && c.Printer.SupportedContentType != nil {
+		for _, sct := range *c.Printer.SupportedContentType {
+			if sct.ContentType == "application/pdf" || sct.ContentType == "*/*" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// createJob passes the ticket arg to the printer's createjob API.
+// Returns the new job ID and true on success.
+// Returns "" and true if the printer doesn't support the createjob API.
+// Returns "" and false on failure.
+func (pc *privetClient) createJob(ticket *cdd.CloudJobTicket) (string, bool) {
+	if !pc.supportsCreateJob() {
+		return "", true
+	}
+
+	body, pe, err := pc.doHTTPRequest("POST", "/privet/printer/createjob", nil, nil, "")
+	if err != nil {
+		common.Error("Failed to create new print job: %s", err)
+		return "", false
+	}
+	if pe != nil {
+		switch *pe.Error {
+		case "printer_busy":
+			// TODO: signal retry to CUPS
+		case "printer_error":
+			// TODO: signal state to CUPS
+		default:
+			common.Error("Printer returned an error: %s", pe.string())
+		}
+		return "", false
+	}
+
+	var newJob struct {
+		JobID     string `json:"job_id"`
+		ExpiresIn int32  `json:"expires_in"`
+	}
+	if err = json.Unmarshal(body, &newJob); err != nil {
+		common.Error("Failed to unmarshal JSON: %s", err)
+		return "", false
+	}
+
+	return newJob.JobID, true
+}
+
+func (pc *privetClient) supportsCreateJob() bool {
+	if pc.latestInfo == nil {
+		common.Error("Cannot call createjob without info() call first")
+		return false
+	}
+	return stringSliceContains("/privet/printer/createjob", pc.latestInfo.API)
+}
+
+// submitDoc passes a file to the printer's submitdoc API.
+// The jobID arg is optional; see "Simple printing" in GCP dev docs.
+// Returns the (new) job ID and true on success.
+// Returns "" and false on failure.
+func (pc *privetClient) submitDoc(jobID, userName, jobName string, body *os.File, contentType string) (string, bool) {
+	// TODO: Do this in a streaming way and update CUPS as progress is made.
+	/*
+		r, w := io.Pipe()
+		go func() {
+		}()
+	*/
+	form := url.Values{}
+	form.Add("job_id", jobID)
+	form.Add("user_name", userName)
+	form.Add("client_name", "TODO CUPS virtual driver")
+	form.Add("job_name", jobName)
+
+	responseBody, pe, err := pc.doHTTPRequest("POST", "/privet/printer/submitdoc", form, body, contentType)
+	if err != nil {
+		common.Error("Failed to submit new print job: %s", err)
+		return "", false
+	}
+	if pe != nil {
+		switch *pe.Error {
+		case "invalid_print_job", "printer_busy":
+			// TODO: signal retry to CUPS
+		default:
+			common.Error("Printer returned an error: %s", pe.string())
+		}
+		return "", false
+	}
+
+	var newJob struct {
+		JobID     string `json:"job_id"`
+		ExpiresIn int32  `json:"expires_in"`
+		JobType   string `json:"job_type"`
+		JobSize   int64  `json:"job_size"`
+		JobName   string `json:"job_name"`
+	}
+	if err := json.Unmarshal(responseBody, &newJob); err != nil {
+		common.Error("Failed to unmarshal JSON: %s", err)
+		return "", false
+	}
+
+	return newJob.JobID, true
+}

--- a/gcp-cups-driver/driver.drv
+++ b/gcp-cups-driver/driver.drv
@@ -1,0 +1,22 @@
+#include <font.defs>
+#include <media.defs>
+
+Manufacturer "Google"
+Version 1.0
+
+*MediaSize Letter
+MediaSize A4
+
+// CDD sections: Color, Duplex, Margins, MediaSize
+
+{
+	Filter application/pdf 0 -
+	PCFileName "gcp-pdf.ppd"
+	ModelName "Cloud Print - PDF"
+}
+
+{
+	Filter image/pwg-raster 0 -
+	PCFileName "gcp-pwg.ppd"
+	ModelName "Cloud Print - PWG Raster"
+}

--- a/gcp-windows-connector/gcp-windows-connector.go
+++ b/gcp-windows-connector/gcp-windows-connector.go
@@ -161,7 +161,7 @@ func (service *service) Execute(args []string, r <-chan svc.ChangeRequest, s cha
 		return false, 1
 	}
 	pm, err := manager.NewPrinterManager(ws, g, nil, nativePrinterPollInterval,
-		config.NativeJobQueueSize, false, config.ShareScope, jobs, xmppNotifications)
+		config.NativeJobQueueSize, *config.CUPSJobFullUsername, *config.JobSpooledIsDone, config.ShareScope, jobs, xmppNotifications)
 	if err != nil {
 		log.Fatal(err)
 		return false, 1

--- a/lib/config.go
+++ b/lib/config.go
@@ -136,6 +136,14 @@ func (c *Config) commonSparse(context *cli.Context) *Config {
 		s.NativePrinterPollInterval == DefaultConfig.NativePrinterPollInterval {
 		s.NativePrinterPollInterval = ""
 	}
+	if !context.IsSet("cups-job-full-username") &&
+		reflect.DeepEqual(s.CUPSJobFullUsername, DefaultConfig.CUPSJobFullUsername) {
+		s.CUPSJobFullUsername = nil
+	}
+	if !context.IsSet("job-spooled-is-done") &&
+		reflect.DeepEqual(s.JobSpooledIsDone, DefaultConfig.JobSpooledIsDone) {
+		s.JobSpooledIsDone = nil
+	}
 	if !context.IsSet("prefix-job-id-to-job-title") &&
 		reflect.DeepEqual(s.PrefixJobIDToJobTitle, DefaultConfig.PrefixJobIDToJobTitle) {
 		s.PrefixJobIDToJobTitle = nil
@@ -194,6 +202,12 @@ func (c *Config) commonBackfill(configMap map[string]interface{}) *Config {
 	}
 	if _, exists := configMap["cups_printer_poll_interval"]; !exists {
 		b.NativePrinterPollInterval = DefaultConfig.NativePrinterPollInterval
+	}
+	if _, exists := configMap["cups_job_full_username"]; !exists {
+		b.CUPSJobFullUsername = DefaultConfig.CUPSJobFullUsername
+	}
+	if _, exists := configMap["job_spooled_is_done"]; !exists {
+		b.JobSpooledIsDone = DefaultConfig.JobSpooledIsDone
 	}
 	if _, exists := configMap["prefix_job_id_to_job_title"]; !exists {
 		b.PrefixJobIDToJobTitle = DefaultConfig.PrefixJobIDToJobTitle

--- a/lib/config_unix.go
+++ b/lib/config_unix.go
@@ -86,6 +86,15 @@ type Config struct {
 	// TODO: rename without cups_ prefix
 	NativePrinterPollInterval string `json:"cups_printer_poll_interval,omitempty"`
 
+	// Use the full username (joe@example.com) in job.
+	// TODO: rename without cups_ prefix
+	CUPSJobFullUsername *bool `json:"cups_job_full_username,omitempty"`
+
+	// When the job finishes spooling, mark it as done.
+	// This is for compatibility with other products that pause jobs to process them.
+	// TODO: this is only in the Windows build for now - decide whether useful in Unix
+	JobSpooledIsDone *bool `json:"job_spooled_is_done,omitempty"`
+
 	// Add the job ID to the beginning of the job title. Useful for debugging.
 	PrefixJobIDToJobTitle *bool `json:"prefix_job_id_to_job_title,omitempty"`
 
@@ -127,9 +136,6 @@ type Config struct {
 
 	// CUPS only: printer attributes to copy to GCP.
 	CUPSPrinterAttributes []string `json:"cups_printer_attributes,omitempty"`
-
-	// CUPS only: use the full username (joe@example.com) in CUPS job.
-	CUPSJobFullUsername *bool `json:"cups_job_full_username,omitempty"`
 
 	// CUPS only: ignore printers with make/model 'Local Raw Printer'.
 	CUPSIgnoreRawPrinters *bool `json:"cups_ignore_raw_printers,omitempty"`

--- a/lib/config_windows.go
+++ b/lib/config_windows.go
@@ -84,6 +84,15 @@ type Config struct {
 	// TODO: rename without cups_ prefix
 	NativePrinterPollInterval string `json:"cups_printer_poll_interval,omitempty"`
 
+	// Use the full username (joe@example.com) in job.
+	// TODO: rename without cups_ prefix
+	CUPSJobFullUsername *bool `json:"cups_job_full_username,omitempty"`
+
+	// When the job finishes spooling, mark it as done.
+	// This is for compatibility with other products that pause jobs to process them.
+	// TODO: this is only in the Windows build for now - decide whether useful in Unix
+	JobSpooledIsDone *bool `json:"job_spooled_is_done,omitempty"`
+
 	// Add the job ID to the beginning of the job title. Useful for debugging.
 	PrefixJobIDToJobTitle *bool `json:"prefix_job_id_to_job_title,omitempty"`
 
@@ -120,6 +129,8 @@ var DefaultConfig = Config{
 
 	NativeJobQueueSize:        3,
 	NativePrinterPollInterval: "1m",
+	CUPSJobFullUsername:       PointerToBool(false),
+	JobSpooledIsDone:          PointerToBool(false),
 	PrefixJobIDToJobTitle:     PointerToBool(false),
 	DisplayNamePrefix:         "",
 	PrinterBlacklist: []string{

--- a/winspool/win32.go
+++ b/winspool/win32.go
@@ -757,7 +757,7 @@ func (hPrinter HANDLE) SetJobCommand(jobID int32, command uint32) error {
 	return nil
 }
 
-func (hPrinter HANDLE) SetJob1(jobID int32, ji1 *JobInfo1) error {
+func (hPrinter HANDLE) SetJobInfo1(jobID int32, ji1 *JobInfo1) error {
 	r1, _, err := setJobProc.Call(uintptr(hPrinter), uintptr(jobID), 1, uintptr(unsafe.Pointer(ji1)), 0)
 	if r1 == 0 {
 		return err
@@ -778,7 +778,7 @@ func (hPrinter HANDLE) SetJobUserName(jobID int32, userName string) error {
 
 	ji1.pUserName = pUserName;
 	ji1.position = 0; // To prevent a possible access denied error (0 is JOB_POSITION_UNSPECIFIED)
-	err = hPrinter.SetJob1(jobID, ji1)
+	err = hPrinter.SetJobInfo1(jobID, ji1)
 	if err != nil {
 		return err
 	}

--- a/winspool/win32.go
+++ b/winspool/win32.go
@@ -573,8 +573,8 @@ func enumPrinters(level uint32) ([]byte, uint32, error) {
 	}
 
 	var pPrinterEnum []byte = make([]byte, cbBuf)
-	_, _, err = enumPrintersProc.Call(PRINTER_ENUM_LOCAL, 0, uintptr(level), uintptr(unsafe.Pointer(&pPrinterEnum[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)), uintptr(unsafe.Pointer(&pcReturned)))
-	if err != NO_ERROR {
+	r1, _, err := enumPrintersProc.Call(PRINTER_ENUM_LOCAL, 0, uintptr(level), uintptr(unsafe.Pointer(&pPrinterEnum[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)), uintptr(unsafe.Pointer(&pcReturned)))
+	if r1 == 0 {
 		return nil, 0, err
 	}
 
@@ -606,16 +606,16 @@ func OpenPrinter(printerName string) (HANDLE, error) {
 	}
 
 	var hPrinter HANDLE
-	_, _, err = openPrinterProc.Call(uintptr(unsafe.Pointer(pPrinterName)), uintptr(unsafe.Pointer(&hPrinter)), 0)
-	if err != NO_ERROR {
+	r1, _, err := openPrinterProc.Call(uintptr(unsafe.Pointer(pPrinterName)), uintptr(unsafe.Pointer(&hPrinter)), 0)
+	if r1 == 0 {
 		return 0, err
 	}
 	return hPrinter, nil
 }
 
 func (hPrinter *HANDLE) ClosePrinter() error {
-	_, _, err := closePrinterProc.Call(uintptr(*hPrinter))
-	if err != NO_ERROR {
+	r1, _, err := closePrinterProc.Call(uintptr(*hPrinter))
+	if r1 == 0 {
 		return err
 	}
 	*hPrinter = 0
@@ -726,8 +726,8 @@ func (hPrinter HANDLE) GetJob(jobID int32) (*JobInfo1, error) {
 	}
 
 	var pJob []byte = make([]byte, cbBuf)
-	_, _, err = getJobProc.Call(uintptr(hPrinter), uintptr(jobID), 1, uintptr(unsafe.Pointer(&pJob[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)))
-	if err != NO_ERROR {
+	r1, _, err := getJobProc.Call(uintptr(hPrinter), uintptr(jobID), 1, uintptr(unsafe.Pointer(&pJob[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)))
+	if r1 == 0 {
 		return nil, err
 	}
 
@@ -749,12 +749,39 @@ const (
 	JOB_CONTROL_RELEASE           uint32 = 9
 )
 
-func (hPrinter HANDLE) SetJob(jobID int32, command uint32) error {
-	_, _, err := setJobProc.Call(uintptr(hPrinter), uintptr(jobID), 0, 0, uintptr(command))
-	if err != NO_ERROR {
+func (hPrinter HANDLE) SetJobCommand(jobID int32, command uint32) error {
+	r1, _, err := setJobProc.Call(uintptr(hPrinter), uintptr(jobID), 0, 0, uintptr(command))
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+func (hPrinter HANDLE) SetJob1(jobID int32, ji1 *JobInfo1) error {
+	r1, _, err := setJobProc.Call(uintptr(hPrinter), uintptr(jobID), 1, uintptr(unsafe.Pointer(ji1)), 0)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+func (hPrinter HANDLE) SetJobUserName(jobID int32, userName string) error {
+	ji1, err := hPrinter.GetJob(jobID)
+	if err != nil {
 		return err
 	}
 
+	pUserName, err := syscall.UTF16PtrFromString(userName)
+	if err != nil {
+		return err
+	}
+
+	ji1.pUserName = pUserName;
+	ji1.position = 0; // To prevent a possible access denied error (0 is JOB_POSITION_UNSPECIFIED)
+	err = hPrinter.SetJob1(jobID, ji1)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -769,7 +796,6 @@ func CreateDC(deviceName string, devMode *DevMode) (HDC, error) {
 	if r1 == 0 {
 		return 0, err
 	}
-
 	return HDC(r1), nil
 }
 
@@ -806,15 +832,15 @@ func (hDC HDC) StartDoc(docName string) (int32, error) {
 	}
 
 	r1, _, err := startDocProc.Call(uintptr(hDC), uintptr(unsafe.Pointer(&docInfo)))
-	if err != NO_ERROR {
+	if r1 <= 0 {
 		return 0, err
 	}
 	return int32(r1), nil
 }
 
 func (hDC HDC) EndDoc() error {
-	_, _, err := endDocProc.Call(uintptr(hDC))
-	if err != NO_ERROR {
+	r1, _, err := endDocProc.Call(uintptr(hDC))
+	if r1 <= 0 {
 		return err
 	}
 	return nil
@@ -827,16 +853,16 @@ func (hDC HDC) AbortDoc() error {
 }
 
 func (hDC HDC) StartPage() error {
-	_, _, err := startPageProc.Call(uintptr(hDC))
-	if err != NO_ERROR {
+	r1, _, err := startPageProc.Call(uintptr(hDC))
+	if r1 <= 0 {
 		return err
 	}
 	return nil
 }
 
 func (hDC HDC) EndPage() error {
-	_, _, err := endPageProc.Call(uintptr(hDC))
-	if err != NO_ERROR {
+	r1, _, err := endPageProc.Call(uintptr(hDC))
+	if r1 <= 0 {
 		return err
 	}
 	return nil
@@ -848,8 +874,8 @@ const (
 )
 
 func (hDC HDC) SetGraphicsMode(iMode int32) error {
-	_, _, err := setGraphicsModeProc.Call(uintptr(hDC), uintptr(iMode))
-	if err != NO_ERROR {
+	r1, _, err := setGraphicsModeProc.Call(uintptr(hDC), uintptr(iMode))
+	if r1 == 0 {
 		return err
 	}
 	return nil


### PR DESCRIPTION
- Implemented cups_job_full_username option in Windows port
- Added job_spooled_is_done option and implemented in Windows port
- Renamed old SetJob to SetJobCommand since it only uses commands
- Added SetJobUserName which is used to change the username
- Corrected error handling for: EnumPrinters, OpenPrinter, ClosePrinter,
GetJob, SetJob, StartDoc, EndDoc, StartPage, EndPage, SetGraphicsMode

Notes
- The job_spooled_is_done feature is for software (like ours) which
pauses the job and takes over the release process. You may want to
rename the option.
- Without global config, passing new options to depth is a bit painful.
It would be easier to pass around a collection.
- I have not added boilerplate "err == NO_ERROR" checks everywhere (for
"The operation completed successfully" errors). Those Windows bugs are
pretty rare.