### PR TITLE
Implemented cups_job_full_username option in Windows port (and more)

### DIFF
--- a/gcp-connector-util/main_windows.go
+++ b/gcp-connector-util/main_windows.go
@@ -221,6 +221,7 @@ func createCloudConfig(context *cli.Context, xmppJID, robotRefreshToken, userRef
 
 		NativeJobQueueSize:        uint(context.Int("native-job-queue-size")),
 		NativePrinterPollInterval: context.String("native-printer-poll-interval"),
+		CUPSJobFullUsername:       lib.PointerToBool(context.Bool("cups-job-full-username")),
 		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,
@@ -239,6 +240,7 @@ func createLocalConfig(context *cli.Context) *lib.Config {
 
 		NativeJobQueueSize:        uint(context.Int("native-job-queue-size")),
 		NativePrinterPollInterval: context.String("native-printer-poll-interval"),
+		CUPSJobFullUsername:       lib.PointerToBool(context.Bool("cups-job-full-username")),
 		PrefixJobIDToJobTitle:     lib.PointerToBool(context.Bool("prefix-job-id-to-job-title")),
 		DisplayNamePrefix:         context.String("display-name-prefix"),
 		PrinterBlacklist:          lib.DefaultConfig.PrinterBlacklist,

--- a/gcp-windows-connector/gcp-windows-connector.go
+++ b/gcp-windows-connector/gcp-windows-connector.go
@@ -161,7 +161,7 @@ func (service *service) Execute(args []string, r <-chan svc.ChangeRequest, s cha
 		return false, 1
 	}
 	pm, err := manager.NewPrinterManager(ws, g, nil, nativePrinterPollInterval,
-		config.NativeJobQueueSize, false, config.ShareScope, jobs, xmppNotifications)
+		config.NativeJobQueueSize, *config.CUPSJobFullUsername, config.ShareScope, jobs, xmppNotifications)
 	if err != nil {
 		log.Fatal(err)
 		return false, 1

--- a/lib/config.go
+++ b/lib/config.go
@@ -136,6 +136,10 @@ func (c *Config) commonSparse(context *cli.Context) *Config {
 		s.NativePrinterPollInterval == DefaultConfig.NativePrinterPollInterval {
 		s.NativePrinterPollInterval = ""
 	}
+	if !context.IsSet("cups-job-full-username") &&
+		reflect.DeepEqual(s.CUPSJobFullUsername, DefaultConfig.CUPSJobFullUsername) {
+		s.CUPSJobFullUsername = nil
+	}
 	if !context.IsSet("prefix-job-id-to-job-title") &&
 		reflect.DeepEqual(s.PrefixJobIDToJobTitle, DefaultConfig.PrefixJobIDToJobTitle) {
 		s.PrefixJobIDToJobTitle = nil
@@ -194,6 +198,9 @@ func (c *Config) commonBackfill(configMap map[string]interface{}) *Config {
 	}
 	if _, exists := configMap["cups_printer_poll_interval"]; !exists {
 		b.NativePrinterPollInterval = DefaultConfig.NativePrinterPollInterval
+	}
+	if _, exists := configMap["cups_job_full_username"]; !exists {
+		b.CUPSJobFullUsername = DefaultConfig.CUPSJobFullUsername
 	}
 	if _, exists := configMap["prefix_job_id_to_job_title"]; !exists {
 		b.PrefixJobIDToJobTitle = DefaultConfig.PrefixJobIDToJobTitle

--- a/lib/config_unix.go
+++ b/lib/config_unix.go
@@ -132,9 +132,6 @@ type Config struct {
 	// CUPS only: printer attributes to copy to GCP.
 	CUPSPrinterAttributes []string `json:"cups_printer_attributes,omitempty"`
 
-	// CUPS only: use the full username (joe@example.com) in CUPS job.
-	CUPSJobFullUsername *bool `json:"cups_job_full_username,omitempty"`
-
 	// CUPS only: ignore printers with make/model 'Local Raw Printer'.
 	CUPSIgnoreRawPrinters *bool `json:"cups_ignore_raw_printers,omitempty"`
 

--- a/lib/config_unix.go
+++ b/lib/config_unix.go
@@ -86,6 +86,10 @@ type Config struct {
 	// TODO: rename without cups_ prefix
 	NativePrinterPollInterval string `json:"cups_printer_poll_interval,omitempty"`
 
+	// Use the full username (joe@example.com) in job.
+	// TODO: rename without cups_ prefix
+	CUPSJobFullUsername *bool `json:"cups_job_full_username,omitempty"`
+
 	// Add the job ID to the beginning of the job title. Useful for debugging.
 	PrefixJobIDToJobTitle *bool `json:"prefix_job_id_to_job_title,omitempty"`
 

--- a/lib/config_windows.go
+++ b/lib/config_windows.go
@@ -84,6 +84,10 @@ type Config struct {
 	// TODO: rename without cups_ prefix
 	NativePrinterPollInterval string `json:"cups_printer_poll_interval,omitempty"`
 
+	// Use the full username (joe@example.com) in job.
+	// TODO: rename without cups_ prefix
+	CUPSJobFullUsername *bool `json:"cups_job_full_username,omitempty"`
+
 	// Add the job ID to the beginning of the job title. Useful for debugging.
 	PrefixJobIDToJobTitle *bool `json:"prefix_job_id_to_job_title,omitempty"`
 
@@ -120,6 +124,7 @@ var DefaultConfig = Config{
 
 	NativeJobQueueSize:        3,
 	NativePrinterPollInterval: "1m",
+	CUPSJobFullUsername:       PointerToBool(false),
 	PrefixJobIDToJobTitle:     PointerToBool(false),
 	DisplayNamePrefix:         "",
 	PrinterBlacklist: []string{

--- a/winspool/win32.go
+++ b/winspool/win32.go
@@ -573,8 +573,8 @@ func enumPrinters(level uint32) ([]byte, uint32, error) {
 	}
 
 	var pPrinterEnum []byte = make([]byte, cbBuf)
-	_, _, err = enumPrintersProc.Call(PRINTER_ENUM_LOCAL, 0, uintptr(level), uintptr(unsafe.Pointer(&pPrinterEnum[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)), uintptr(unsafe.Pointer(&pcReturned)))
-	if err != NO_ERROR {
+	r1, _, err := enumPrintersProc.Call(PRINTER_ENUM_LOCAL, 0, uintptr(level), uintptr(unsafe.Pointer(&pPrinterEnum[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)), uintptr(unsafe.Pointer(&pcReturned)))
+	if r1 == 0 {
 		return nil, 0, err
 	}
 
@@ -606,16 +606,16 @@ func OpenPrinter(printerName string) (HANDLE, error) {
 	}
 
 	var hPrinter HANDLE
-	_, _, err = openPrinterProc.Call(uintptr(unsafe.Pointer(pPrinterName)), uintptr(unsafe.Pointer(&hPrinter)), 0)
-	if err != NO_ERROR {
+	r1, _, err := openPrinterProc.Call(uintptr(unsafe.Pointer(pPrinterName)), uintptr(unsafe.Pointer(&hPrinter)), 0)
+	if r1 == 0 {
 		return 0, err
 	}
 	return hPrinter, nil
 }
 
 func (hPrinter *HANDLE) ClosePrinter() error {
-	_, _, err := closePrinterProc.Call(uintptr(*hPrinter))
-	if err != NO_ERROR {
+	r1, _, err := closePrinterProc.Call(uintptr(*hPrinter))
+	if r1 == 0 {
 		return err
 	}
 	*hPrinter = 0
@@ -726,8 +726,8 @@ func (hPrinter HANDLE) GetJob(jobID int32) (*JobInfo1, error) {
 	}
 
 	var pJob []byte = make([]byte, cbBuf)
-	_, _, err = getJobProc.Call(uintptr(hPrinter), uintptr(jobID), 1, uintptr(unsafe.Pointer(&pJob[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)))
-	if err != NO_ERROR {
+	r1, _, err := getJobProc.Call(uintptr(hPrinter), uintptr(jobID), 1, uintptr(unsafe.Pointer(&pJob[0])), uintptr(cbBuf), uintptr(unsafe.Pointer(&cbBuf)))
+	if r1 == 0 {
 		return nil, err
 	}
 
@@ -749,12 +749,39 @@ const (
 	JOB_CONTROL_RELEASE           uint32 = 9
 )
 
-func (hPrinter HANDLE) SetJob(jobID int32, command uint32) error {
-	_, _, err := setJobProc.Call(uintptr(hPrinter), uintptr(jobID), 0, 0, uintptr(command))
-	if err != NO_ERROR {
+func (hPrinter HANDLE) SetJobCommand(jobID int32, command uint32) error {
+	r1, _, err := setJobProc.Call(uintptr(hPrinter), uintptr(jobID), 0, 0, uintptr(command))
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+func (hPrinter HANDLE) SetJobInfo1(jobID int32, ji1 *JobInfo1) error {
+	r1, _, err := setJobProc.Call(uintptr(hPrinter), uintptr(jobID), 1, uintptr(unsafe.Pointer(ji1)), 0)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+func (hPrinter HANDLE) SetJobUserName(jobID int32, userName string) error {
+	ji1, err := hPrinter.GetJob(jobID)
+	if err != nil {
 		return err
 	}
 
+	pUserName, err := syscall.UTF16PtrFromString(userName)
+	if err != nil {
+		return err
+	}
+
+	ji1.pUserName = pUserName;
+	ji1.position = 0; // To prevent a possible access denied error (0 is JOB_POSITION_UNSPECIFIED)
+	err = hPrinter.SetJobInfo1(jobID, ji1)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -769,7 +796,6 @@ func CreateDC(deviceName string, devMode *DevMode) (HDC, error) {
 	if r1 == 0 {
 		return 0, err
 	}
-
 	return HDC(r1), nil
 }
 
@@ -806,15 +832,15 @@ func (hDC HDC) StartDoc(docName string) (int32, error) {
 	}
 
 	r1, _, err := startDocProc.Call(uintptr(hDC), uintptr(unsafe.Pointer(&docInfo)))
-	if err != NO_ERROR {
+	if r1 <= 0 {
 		return 0, err
 	}
 	return int32(r1), nil
 }
 
 func (hDC HDC) EndDoc() error {
-	_, _, err := endDocProc.Call(uintptr(hDC))
-	if err != NO_ERROR {
+	r1, _, err := endDocProc.Call(uintptr(hDC))
+	if r1 <= 0 {
 		return err
 	}
 	return nil
@@ -827,16 +853,16 @@ func (hDC HDC) AbortDoc() error {
 }
 
 func (hDC HDC) StartPage() error {
-	_, _, err := startPageProc.Call(uintptr(hDC))
-	if err != NO_ERROR {
+	r1, _, err := startPageProc.Call(uintptr(hDC))
+	if r1 <= 0 {
 		return err
 	}
 	return nil
 }
 
 func (hDC HDC) EndPage() error {
-	_, _, err := endPageProc.Call(uintptr(hDC))
-	if err != NO_ERROR {
+	r1, _, err := endPageProc.Call(uintptr(hDC))
+	if r1 <= 0 {
 		return err
 	}
 	return nil
@@ -848,8 +874,8 @@ const (
 )
 
 func (hDC HDC) SetGraphicsMode(iMode int32) error {
-	_, _, err := setGraphicsModeProc.Call(uintptr(hDC), uintptr(iMode))
-	if err != NO_ERROR {
+	r1, _, err := setGraphicsModeProc.Call(uintptr(hDC), uintptr(iMode))
+	if r1 == 0 {
 		return err
 	}
 	return nil


### PR DESCRIPTION
- Implemented cups_job_full_username option in Windows port
- Changed the job status logic to treat paused jobs as "done" (because
other software may pause jobs, and we aren't checking for the native
printed/deleted statuses)
- Renamed SetJob to SetJobCommand since it only uses commands
- Added SetJobInfo1 & SetJobUserName which are used to change the
username
- Corrected error handling for: EnumPrinters, OpenPrinter, ClosePrinter,
GetJob, SetJobCommand, StartDoc, EndDoc, StartPage, EndPage,
SetGraphicsMode

Note
I have not added boilerplate "err == NO_ERROR" checks everywhere like
SetWorldTransform has. Those "The operation completed successfully"
Windows bugs are pretty rare.