### PR TITLE
Correct the use of color when translated from attrs (not PPD)

### DIFF
--- a/cups/translate-attrs.go
+++ b/cups/translate-attrs.go
@@ -434,17 +434,17 @@ func convertCopies(printerTags map[string][]string) *cdd.Copies {
 
 var colorByKeyword = map[string]cdd.ColorOption{
 	"auto": cdd.ColorOption{
-		VendorID: fmt.Sprintf("%s%s%s", attrPrintColorMode, internalKeySeparator, "auto"),
+		VendorID: "auto",
 		Type:     cdd.ColorTypeAuto,
 		CustomDisplayNameLocalized: cdd.NewLocalizedString("Auto"),
 	},
 	"color": cdd.ColorOption{
-		VendorID: fmt.Sprintf("%s%s%s", attrPrintColorMode, internalKeySeparator, "color"),
+		VendorID: "color",
 		Type:     cdd.ColorTypeStandardColor,
 		CustomDisplayNameLocalized: cdd.NewLocalizedString("Color"),
 	},
 	"monochrome": cdd.ColorOption{
-		VendorID: fmt.Sprintf("%s%s%s", attrPrintColorMode, internalKeySeparator, "monochrome"),
+		VendorID: "monochrome",
 		Type:     cdd.ColorTypeStandardMonochrome,
 		CustomDisplayNameLocalized: cdd.NewLocalizedString("Monochrome"),
 	},
@@ -461,13 +461,13 @@ func convertColorAttrs(printerTags map[string][]string) *cdd.Color {
 		colorDefault = colorSupported[:1]
 	}
 
-	var c cdd.Color
+	c := cdd.Color{VendorKey: attrPrintColorMode}
 	for _, color := range colorSupported {
 		var co cdd.ColorOption
 		var exists bool
 		if co, exists = colorByKeyword[color]; !exists {
 			co = cdd.ColorOption{
-				VendorID: fmt.Sprintf("%s%s%s", attrPrintColorMode, internalKeySeparator, color),
+				VendorID: color,
 				Type:     cdd.ColorTypeCustomColor,
 				CustomDisplayNameLocalized: cdd.NewLocalizedString(color),
 			}

--- a/cups/translate-attrs_test.go
+++ b/cups/translate-attrs_test.go
@@ -585,11 +585,12 @@ func TestConvertColorAttrs(t *testing.T) {
 	}
 	expected := &cdd.Color{
 		Option: []cdd.ColorOption{
-			cdd.ColorOption{"print-color-mode:color", cdd.ColorTypeStandardColor, "", false, cdd.NewLocalizedString("Color")},
-			cdd.ColorOption{"print-color-mode:monochrome", cdd.ColorTypeStandardMonochrome, "", false, cdd.NewLocalizedString("Monochrome")},
-			cdd.ColorOption{"print-color-mode:auto", cdd.ColorTypeAuto, "", true, cdd.NewLocalizedString("Auto")},
-			cdd.ColorOption{"print-color-mode:zebra", cdd.ColorTypeCustomColor, "", false, cdd.NewLocalizedString("zebra")},
+			cdd.ColorOption{"color", cdd.ColorTypeStandardColor, "", false, cdd.NewLocalizedString("Color")},
+			cdd.ColorOption{"monochrome", cdd.ColorTypeStandardMonochrome, "", false, cdd.NewLocalizedString("Monochrome")},
+			cdd.ColorOption{"auto", cdd.ColorTypeAuto, "", true, cdd.NewLocalizedString("Auto")},
+			cdd.ColorOption{"zebra", cdd.ColorTypeCustomColor, "", false, cdd.NewLocalizedString("zebra")},
 		},
+		VendorKey: "print-color-mode",
 	}
 	c = convertColorAttrs(pt)
 	if !reflect.DeepEqual(expected, c) {


### PR DESCRIPTION
Colors were being set in the CDD and ticket structures as VendorKey:"", VendorId:"key:value". Now we properly do VendorKey:"key", VendorId:"value".

Fixes issue #230.