### PR TITLE
Add support for the optional "note" privet TXT field

### DIFF
--- a/privet/avahi.go
+++ b/privet/avahi.go
@@ -26,6 +26,7 @@ var (
 	txtversKey     = C.CString("txtvers")
 	txtversValue   = C.CString("1")
 	tyKey          = C.CString("ty")
+	noteKey        = C.CString("note")
 	urlKey         = C.CString("url")
 	typeKey        = C.CString("type")
 	typeValue      = C.CString("printer")
@@ -41,6 +42,7 @@ type record struct {
 	name   *C.char
 	port   uint16
 	ty     string
+	note   string
 	url    string
 	id     string
 	online bool
@@ -81,7 +83,7 @@ func newZeroconf() (*zeroconf, error) {
 	return &z, nil
 }
 
-func prepareTXT(ty, url, id string, online bool) *C.AvahiStringList {
+func prepareTXT(ty, note, url, id string, online bool) *C.AvahiStringList {
 	var txt *C.AvahiStringList
 	txt = C.avahi_string_list_add_pair(txt, txtversKey, txtversValue)
 	txt = C.avahi_string_list_add_pair(txt, typeKey, typeValue)
@@ -89,6 +91,12 @@ func prepareTXT(ty, url, id string, online bool) *C.AvahiStringList {
 	tyValue := C.CString(ty)
 	defer C.free(unsafe.Pointer(tyValue))
 	txt = C.avahi_string_list_add_pair(txt, tyKey, tyValue)
+
+	if note != "" {
+		noteValue := C.CString(note)
+		defer C.free(unsafe.Pointer(noteValue))
+		txt = C.avahi_string_list_add_pair(txt, noteKey, noteValue)
+	}
 
 	urlValue := C.CString(url)
 	defer C.free(unsafe.Pointer(urlValue))
@@ -107,11 +115,12 @@ func prepareTXT(ty, url, id string, online bool) *C.AvahiStringList {
 	return txt
 }
 
-func (z *zeroconf) addPrinter(name string, port uint16, ty, url, id string, online bool) error {
+func (z *zeroconf) addPrinter(name string, port uint16, ty, note, url, id string, online bool) error {
 	r := record{
 		name:   C.CString(name),
 		port:   port,
 		ty:     ty,
+		note:   note,
 		url:    url,
 		id:     id,
 		online: online,
@@ -124,7 +133,7 @@ func (z *zeroconf) addPrinter(name string, port uint16, ty, url, id string, onli
 		return fmt.Errorf("printer %s was already added to Avahi publishing", name)
 	}
 	if z.state == C.AVAHI_CLIENT_S_RUNNING {
-		txt := prepareTXT(ty, url, id, online)
+		txt := prepareTXT(ty, note, url, id, online)
 		defer C.avahi_string_list_free(txt)
 
 		C.avahi_threaded_poll_lock(z.threadedPoll)
@@ -140,7 +149,7 @@ func (z *zeroconf) addPrinter(name string, port uint16, ty, url, id string, onli
 	return nil
 }
 
-func (z *zeroconf) updatePrinterTXT(name, ty, url, id string, online bool) error {
+func (z *zeroconf) updatePrinterTXT(name, ty, note, url, id string, online bool) error {
 	z.spMutex.Lock()
 	defer z.spMutex.Unlock()
 
@@ -155,7 +164,7 @@ func (z *zeroconf) updatePrinterTXT(name, ty, url, id string, online bool) error
 	r.online = online
 
 	if z.state == C.AVAHI_CLIENT_S_RUNNING && r.group != nil {
-		txt := prepareTXT(ty, url, id, online)
+		txt := prepareTXT(ty, note, url, id, online)
 		defer C.avahi_string_list_free(txt)
 
 		C.avahi_threaded_poll_lock(z.threadedPoll)
@@ -262,7 +271,7 @@ func handleClientStateChange(client *C.AvahiClient, newState C.AvahiClientState,
 	if newState == C.AVAHI_CLIENT_S_RUNNING {
 		log.Info("Local printing enabled (Avahi client is running).")
 		for name, r := range z.printers {
-			txt := prepareTXT(r.ty, r.url, r.id, r.online)
+			txt := prepareTXT(r.ty, r.note, r.url, r.id, r.online)
 			defer C.avahi_string_list_free(txt)
 
 			if errstr := C.addAvahiGroup(z.threadedPoll, z.client, &r.group, r.name, C.ushort(r.port), txt); errstr != nil {

--- a/privet/bonjour.c
+++ b/privet/bonjour.c
@@ -51,10 +51,11 @@ void registerCallback(CFNetServiceRef service, CFStreamError *streamError, void 
 // startBonjour starts and returns a bonjour service.
 //
 // Returns a registered service. Returns NULL and sets err on failure.
-CFNetServiceRef startBonjour(const char *name, const char *type, unsigned short int port, const char *ty, const char *url, const char *id, const char *cs, char **err) {
+CFNetServiceRef startBonjour(const char *name, const char *type, unsigned short int port, const char *ty, const char *note, const char *url, const char *id, const char *cs, char **err) {
 	CFStringRef nameCF = CFStringCreateWithCString(NULL, name, kCFStringEncodingASCII);
 	CFStringRef typeCF = CFStringCreateWithCString(NULL, type, kCFStringEncodingASCII);
 	CFStringRef tyCF = CFStringCreateWithCString(NULL, ty, kCFStringEncodingASCII);
+        CFStringRef noteCF = CFStringCreateWithCString(NULL, note, kCFStringEncodingASCII);
 	CFStringRef urlCF = CFStringCreateWithCString(NULL, url, kCFStringEncodingASCII);
 	CFStringRef idCF = CFStringCreateWithCString(NULL, id, kCFStringEncodingASCII);
 	CFStringRef csCF = CFStringCreateWithCString(NULL, cs, kCFStringEncodingASCII);
@@ -63,6 +64,9 @@ CFNetServiceRef startBonjour(const char *name, const char *type, unsigned short 
 			&kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 	CFDictionarySetValue(dict, CFSTR("txtvers"), CFSTR("1"));
 	CFDictionarySetValue(dict, CFSTR("ty"), tyCF);
+        if (CFStringGetLength(noteCF) > 0) {
+		CFDictionarySetValue(dict, CFSTR("note"), noteCF);
+        }
 	CFDictionarySetValue(dict, CFSTR("url"), urlCF);
 	CFDictionarySetValue(dict, CFSTR("type"), CFSTR("printer"));
 	CFDictionarySetValue(dict, CFSTR("id"), idCF);
@@ -89,6 +93,7 @@ CFNetServiceRef startBonjour(const char *name, const char *type, unsigned short 
 
 	CFRelease(typeCF);
 	CFRelease(tyCF);
+	CFRelease(noteCF);
 	CFRelease(urlCF);
 	CFRelease(idCF);
 	CFRelease(csCF);
@@ -99,8 +104,9 @@ CFNetServiceRef startBonjour(const char *name, const char *type, unsigned short 
 }
 
 // updateBonjour updates the TXT record of service.
-void updateBonjour(CFNetServiceRef service, const char *ty, const char *url, const char *id, const char *cs) {
+void updateBonjour(CFNetServiceRef service, const char *ty, const char *note, const char *url, const char *id, const char *cs) {
 	CFStringRef tyCF = CFStringCreateWithCString(NULL, ty, kCFStringEncodingASCII);
+	CFStringRef noteCF = CFStringCreateWithCString(NULL, note, kCFStringEncodingASCII);
 	CFStringRef urlCF = CFStringCreateWithCString(NULL, url, kCFStringEncodingASCII);
 	CFStringRef idCF = CFStringCreateWithCString(NULL, id, kCFStringEncodingASCII);
 	CFStringRef csCF = CFStringCreateWithCString(NULL, cs, kCFStringEncodingASCII);
@@ -109,6 +115,9 @@ void updateBonjour(CFNetServiceRef service, const char *ty, const char *url, con
 			&kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 	CFDictionarySetValue(dict, CFSTR("txtvers"), CFSTR("1"));
 	CFDictionarySetValue(dict, CFSTR("ty"), tyCF);
+        if (CFStringGetLength(noteCF) > 0) {
+		CFDictionarySetValue(dict, CFSTR("note"), noteCF);
+        }
 	CFDictionarySetValue(dict, CFSTR("url"), urlCF);
 	CFDictionarySetValue(dict, CFSTR("type"), CFSTR("printer"));
 	CFDictionarySetValue(dict, CFSTR("id"), idCF);
@@ -118,6 +127,7 @@ void updateBonjour(CFNetServiceRef service, const char *ty, const char *url, con
 	CFNetServiceSetTXTData(service, txt);
 
 	CFRelease(tyCF);
+	CFRelease(noteCF);
 	CFRelease(urlCF);
 	CFRelease(idCF);
 	CFRelease(csCF);

--- a/privet/bonjour.h
+++ b/privet/bonjour.h
@@ -14,8 +14,8 @@
 #include <stdlib.h> // free
 
 CFNetServiceRef startBonjour(const char *name, const char *type,
-		unsigned short int port, const char *ty, const char *url, const char *id,
-		const char *cs, char **err);
-void updateBonjour(CFNetServiceRef service, const char *ty, const char *url,
+		unsigned short int port, const char *ty, const char *note, const char *url,
+		const char *id, const char *cs, char **err);
+void updateBonjour(CFNetServiceRef service, const char *ty, const char *note, const char *url,
 		const char *id, const char *cs);
 void stopBonjour(CFNetServiceRef service);

--- a/privet/privet.go
+++ b/privet/privet.go
@@ -76,7 +76,7 @@ func (p *Privet) AddPrinter(printer lib.Printer, getPrinter func(string) (lib.Pr
 	if online {
 		localDefaultDisplayName = fmt.Sprintf("%s (local)", localDefaultDisplayName)
 	}
-	err = p.zc.addPrinter(printer.Name, api.port(), localDefaultDisplayName, p.gcpBaseURL, printer.GCPID, online)
+	err = p.zc.addPrinter(printer.Name, api.port(), localDefaultDisplayName, "", p.gcpBaseURL, printer.GCPID, online)
 	if err != nil {
 		api.quit()
 		return err
@@ -102,7 +102,7 @@ func (p *Privet) UpdatePrinter(diff *lib.PrinterDiff) error {
 		localDefaultDisplayName = fmt.Sprintf("%s (local)", localDefaultDisplayName)
 	}
 
-	return p.zc.updatePrinterTXT(diff.Printer.GCPID, localDefaultDisplayName, p.gcpBaseURL, diff.Printer.GCPID, online)
+	return p.zc.updatePrinterTXT(diff.Printer.GCPID, localDefaultDisplayName, "", p.gcpBaseURL, diff.Printer.GCPID, online)
 }
 
 // DeletePrinter removes a printer from Privet.


### PR DESCRIPTION
This field matches "description" in /privet/info, which is currently unused.

I am not quite sure if this is the correct way to go, since https://developers.google.com/cloud-print/docs/privet#22-txt-record says:
> The same description MUST be used when registering device.

But https://developers.google.com/cloud-print/docs/proxyinterfaces#register says:
> description (deprecated)

Still, we probably should be consistent within the privet specification.