### PR TITLE
Remove description field from /privet/info response

### DIFF
--- a/privet/api-server.go
+++ b/privet/api-server.go
@@ -133,7 +133,6 @@ func (api *privetAPI) serve() {
 type infoResponse struct {
 	Version         string               `json:"version"`
 	Name            string               `json:"name"`
-	Description     string               `json:"description"`
 	URL             string               `json:"url"`
 	Type            []string             `json:"type"`
 	ID              string               `json:"id"`


### PR DESCRIPTION
It's not completely clear, but
https://developers.google.com/cloud-print/docs/privet#42-privetinfo-api
says that we should put 'note' in the TXT record if 'description' is used.
From https://developers.google.com/cloud-print/docs/privet#22-txt-record
we see that the same note "MUST be used when registering device".
From https://developers.google.com/cloud-print/docs/proxyinterfaces#register
we see that 'description' is deprecated.

So maybe it should be deprecated here as well. We never use it and it is
an optional field.