### PR TITLE
Fix Windows build break in Privet from #237

### DIFF
--- a/privet/windows.go
+++ b/privet/windows.go
@@ -18,11 +18,11 @@ func newZeroconf() (*zeroconf, error) {
 	return nil, errors.New("Privet has not been implemented for Windows")
 }
 
-func (z *zeroconf) addPrinter(name string, port uint16, ty, url, id string, online bool) error {
+func (z *zeroconf) addPrinter(name string, port uint16, ty, note, url, id string, online bool) error {
 	return nil
 }
 
-func (z *zeroconf) updatePrinterTXT(name, ty, url, id string, online bool) error {
+func (z *zeroconf) updatePrinterTXT(name, ty, note, url, id string, online bool) error {
 	return nil
 }
 


### PR DESCRIPTION
Trivial fixes for Windows build errors introduced in #237:
cups-connector\privet\privet.go:79: too many arguments in call to p.zc.addPrinter
cups-connector\privet\privet.go:105: too many arguments in call to p.zc.updatePrinterTXT

Is Travis CI for Windows still not there yet? Luckily for me the CI catches my Unix build breaks. ; - )